### PR TITLE
ECI-221 Add default namespaces when creating connector hub

### DIFF
--- a/datadog-oci-orm/metrics-setup/locals.tf
+++ b/datadog-oci-orm/metrics-setup/locals.tf
@@ -9,6 +9,7 @@ locals {
 locals {
   # Names for the service connector
   connector_name = "${var.resource_name_prefix}-connector"
+  connector_metric_namespaces = ["oci_autonomous_database", "oci_blockstore", "oci_compute_infrastructure_health", "oci_computeagent", "oci_computecontainerinstance", "oci_database", "oci_database_cluster", "oci_dynamic_routing_gateway", "oci_faas", "oci_fastconnect", "oci_filestorage", "oci_gpu_infrastructure_health", "oci_lbaas", "oci_mysql_database", "oci_nat_gateway", "oci_nlb", "oci_objectstorage", "oci_oke", "oci_queue", "oci_rdma_infrastructure_health", "oci_service_connector_hub", "oci_service_gateway", "oci_vcn", "oci_vpn", "oci_waf", "oracle_oci_database"]
 }
 
 locals {
@@ -36,6 +37,6 @@ locals {
   ocir_repo_name        = "${var.resource_name_prefix}-functions"
   function_name         = "datadog-function-metrics"
   docker_image_path     = "${local.oci_docker_repository}/${local.ocir_repo_name}/${local.function_name}:latest"
-  custom_image_path   = var.function_image_path
-  user_image_provided = length(var.function_image_path) > 0 ? true : false
+  custom_image_path     = var.function_image_path
+  user_image_provided   = length(var.function_image_path) > 0 ? true : false
 }

--- a/datadog-oci-orm/metrics-setup/serviceconnector.tf
+++ b/datadog-oci-orm/metrics-setup/serviceconnector.tf
@@ -13,15 +13,16 @@ resource "oci_sch_service_connector" "metrics_service_connector" {
       #Optional
       compartment_id = var.tenancy_ocid
       namespace_details {
-        #Required
         kind = "selected"
-        namespaces {
-          #Required
-          metrics {
-            #Required
-            kind = "all"
+        dynamic "namespaces" {
+          for_each = local.connector_metric_namespaces
+          content {
+            metrics {
+              #Required
+              kind = "all"
+            }
+            namespace = namespaces.value
           }
-          namespace = "oci_computeagent"
         }
       }
     }


### PR DESCRIPTION
* Add default namespaces when creating connector hub
* Currently limited to 50 total namespaces for a single connector hub