### PR TITLE
ECI-161 Fix ddsource in log forwarding function

### DIFF
--- a/Object Store/func.py
+++ b/Object Store/func.py
@@ -7,7 +7,7 @@ import logging
 import oci
 import requests
 
-DD_SOURCE = "Oracle Cloud"  # Adding a source name.
+DD_SOURCE = "oracle_cloud"  # Adding a source name.
 DD_SERVICE = "OCI Logs"  # Adding a service name.
 DD_TIMEOUT = 10 * 60  # Adding a timeout for the Datadog API call.
 

--- a/Service Connector  Hub/func.py
+++ b/Service Connector  Hub/func.py
@@ -7,7 +7,7 @@ import requests
 
 logger = logging.getLogger(__name__)
 
-DD_SOURCE = "Oracle Cloud"  # Adding a source name.
+DD_SOURCE = "oracle_cloud"  # Adding a source name.
 DD_SERVICE = "OCI Logs"  # Adding a service name.
 DD_TIMEOUT = 10 * 60  # Adding a timeout for the Datadog API call.
 
@@ -22,7 +22,7 @@ def process(body: dict) -> None:
     payload.update({"source": source})
     payload.update({"time": time})
     payload.update({"data": data})
-    payload.update({"ddsource": DD_SERVICE})
+    payload.update({"ddsource": DD_SOURCE})
     payload.update({"service": DD_SERVICE})
 
     # Datadog endpoint URL and token to call the REST interface.


### PR DESCRIPTION
**what:**
* Change source constant to `oracle_cloud` in log forwarding function
* In service connector log forwarding function, change `ddsource` field value to `oracle_cloud`

**why:**
* The log forwarding takes the the `ddsource` value as `oracle_cloud` without that the logs are not accepted