### PR TITLE
ECI-258 Terraform stack update that adds an auth user, group and policy

### DIFF
--- a/datadog-oci-orm/policy-setup/policy.tf
+++ b/datadog-oci-orm/policy-setup/policy.tf
@@ -18,6 +18,7 @@ provider "oci" {
 
 locals {
   tenancy_home_region = data.oci_identity_tenancy.tenancy_metadata.home_region_key
+  read_policy_group = var.dynamic_group_name
   freeform_tags = {
     datadog-terraform = "true"
   }
@@ -35,15 +36,48 @@ resource "oci_identity_dynamic_group" "serviceconnector_group" {
   freeform_tags = local.freeform_tags
 }
 
+resource "oci_identity_user" "read_only_user" {
+    #Required
+    compartment_id = var.tenancy_ocid
+    description = "[DO NOT REMOVE] Read only user created for fetching resources metadata which is used by Datadog Integrations"
+    name = "DatadogAuthUser"
+    email = "test@test.com"
+
+    #Optional
+    defined_tags = {}
+    freeform_tags = local.freeform_tags
+}
+
+resource "oci_identity_group" "read_policy_group" {
+  depends_on     = [oci_identity_user.read_only_user]
+  #Required
+  compartment_id = var.tenancy_ocid
+  description    = "[DO NOT REMOVE] Group for adding a user for having read-only permissions of resources"
+  name           = var.user_group_name
+
+  #Optional
+  defined_tags  = {}
+  freeform_tags = local.freeform_tags
+}
+
+resource "oci_identity_user_group_membership" "dd_user_group_membership" {
+    depends_on     = [oci_identity_user.read_only_user, oci_identity_group.read_policy_group]
+    #Required
+    group_id = oci_identity_group.read_policy_group.id
+    user_id = oci_identity_user.read_only_user.id
+}
+
 resource "oci_identity_policy" "metrics_policy" {
-  depends_on     = [oci_identity_dynamic_group.serviceconnector_group]
+  depends_on     = [oci_identity_dynamic_group.serviceconnector_group, oci_identity_user_group_membership.dd_user_group_membership]
   compartment_id = var.tenancy_ocid
   description    = "[DO NOT REMOVE] Policy to have any connector hub read from monitoring source and write to a target function"
   name           = var.datadog_metrics_policy
   statements = ["Allow dynamic-group ${var.dynamic_group_name} to read metrics in tenancy",
     "Allow dynamic-group ${var.dynamic_group_name} to use fn-function in tenancy",
-    "Allow dynamic-group ${var.dynamic_group_name} to use fn-invocation in tenancy"
+    "Allow dynamic-group ${var.dynamic_group_name} to use fn-invocation in tenancy",
+    "Allow group ${var.user_domain}/${oci_identity_group.read_policy_group.name} to read all-resources in tenancy"
   ]
   defined_tags  = {}
   freeform_tags = local.freeform_tags
 }
+

--- a/datadog-oci-orm/policy-setup/variables.tf
+++ b/datadog-oci-orm/policy-setup/variables.tf
@@ -16,9 +16,22 @@ variable "dynamic_group_name" {
   default     = "datadog-metrics-dynamic-group"
 }
 
+variable "user_group_name" {
+  type        = string
+  description = "The name of the group for giving access to user"
+  default     = "DatadogAuthGroup"
+}
+
 variable "datadog_metrics_policy" {
   type        = string
   description = "The name of the policy for metrics"
   default     = "datadog-metrics-policy"
 }
+
+variable "user_domain" {
+  type        = string
+  description = "The name of the domain where the operation is to be run. It is assumed that the setup will create users and groups in the default domain. Enter the domain name if the user running the setup does not belong to Default domain."
+  default     = "Default"
+}
+
 

--- a/datadog-oci-orm/policy-setup/variables.tf
+++ b/datadog-oci-orm/policy-setup/variables.tf
@@ -30,7 +30,7 @@ variable "datadog_metrics_policy" {
 
 variable "user_domain" {
   type        = string
-  description = "The name of the domain where the operation is to be run. It is assumed that the setup will create users and groups in the default domain. Enter the domain name if the user running the setup does not belong to Default domain."
+  description = "The name of the domain where the operation is to be run. By default the users and groups will be created in the domain of the current user running the setup. If the user running this setup does not belong to the Default domain, enter the domain name they belong to here."
   default     = "Default"
 }
 


### PR DESCRIPTION
**what:**

* Update the terraform stack in OCI policy setup to create a user, user group and policy for the user to read resources in the tenancy

**why:**

* Step in the  the ease of setup of automated creation of policy and user

**testing:**

[Created stack job](https://cloud.oracle.com/resourcemanager/jobs/ocid1.ormjob.oc1.iad.amaaaaaaehwejaiaow7txjuiazzauzyhhxuecrei6tyhzwhvq65b2nk5pyya?region=us-ashburn-1)