### PR TITLE
[ECI-236] Batch logs

### DIFF
--- a/Service Connector  Hub/func.yaml
+++ b/Service Connector  Hub/func.yaml
@@ -6,6 +6,7 @@ entrypoint: /python/bin/fdk /function/func.py handler
 memory: 1024
 timeout: 120
 config:
-  DATADOG_HOST: https://http-intake.logs.datadoghq.com/api/v2/logs  # DD Log Intake Host
+  DATADOG_HOST: http-intake.logs.datadoghq.com                      # DD Log Intake Host
   DATADOG_TOKEN: <DATADOG_API_TOKEN>                                # DD API Token
+  DD_COMPRESS: "true"                                               # Enable Compression
   # DATADOG_TAGS: "prod:true"                                       # Tags associated with logs

--- a/Service Connector  Hub/tests/test_func.py
+++ b/Service Connector  Hub/tests/test_func.py
@@ -67,8 +67,9 @@ class TestLogForwarderFunction(TestCase):
 
     def setUp(self):
         # Set env variables expected by function
-        os.environ['DATADOG_HOST'] = "http://datadog.woof"
+        os.environ['DATADOG_HOST'] = "test-intake.logs.datadoghq.com"
         os.environ['DATADOG_TOKEN'] = "VERY-SECRET-TOKEN-2000"
+        os.environ['DD_COMPRESS'] = "true"
         return super().setUp()
 
 

--- a/Service Connector  Hub/tests/test_func.py
+++ b/Service Connector  Hub/tests/test_func.py
@@ -6,7 +6,7 @@ from io import BytesIO
 # Add the directory containing func.py to the Python path
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '../')))
 
-from func import handler
+from func import handler, DD_BATCH_SIZE
 from unittest import TestCase, mock
 
 
@@ -14,12 +14,15 @@ def to_bytes_io(inp : str):
     """ Helper function to turn string test data into expected BytesIO asci encoded bytes """
     return BytesIO(bytes(inp, 'ascii'))
 
+
 def _decompress_string(compressed_string):
     """Decompresses a gzip-compressed string."""
     return gzip.decompress(compressed_string).decode()
 
-def to_decompressed_dict(data) -> dict :
+
+def to_decompressed_data(data) -> list[dict] :
     return eval(_decompress_string(data))
+
 
 class TestLogForwarderFunction(TestCase):
     """ Test simple and batch format json CloudEvent payloads """
@@ -46,18 +49,20 @@ class TestLogForwarderFunction(TestCase):
         }
     """
 
-    SAMPLE_OUTPUT = {
-        "source": "Log_Connector",
-        "timestamp": "2024-09-25T20:04:45.130Z",
-        "data":
+    SAMPLE_OUTPUT = [
         {
-            "level": "INFO",
-            "message": "Run succeeded - Read 0 messages from source and wrote 0 messages to target",
-            "messageType": "CONNECTOR_RUN_COMPLETED"
-        },
-        "ddsource": "oracle_cloud",
-        "service": "OCI Logs"
-    }
+            "source": "Log_Connector",
+            "timestamp": "2024-09-25T20:04:45.130Z",
+            "data":
+            {
+                "level": "INFO",
+                "message": "Run succeeded - Read 0 messages from source and wrote 0 messages to target",
+                "messageType": "CONNECTOR_RUN_COMPLETED"
+            },
+            "ddsource": "oracle_cloud",
+            "service": "OCI Logs"
+        }
+    ]
 
 
     def setUp(self):
@@ -72,11 +77,12 @@ class TestLogForwarderFunction(TestCase):
         """ Test single CloudEvent payload """
 
         payload = TestLogForwarderFunction.SAMPLE_INPUT
+        mock_post.reset_mock()
         handler(ctx=None, data=to_bytes_io(payload))
         mock_post.assert_called_once()
-        self.assertDictEqual(
+        self.assertEqual(
             TestLogForwarderFunction.SAMPLE_OUTPUT,
-            to_decompressed_dict(mock_post.mock_calls[0].kwargs['data'])
+            to_decompressed_data(mock_post.mock_calls[0].kwargs['data'])
         )
         self.assertEqual(
             "gzip",
@@ -91,28 +97,39 @@ class TestLogForwarderFunction(TestCase):
         payload = TestLogForwarderFunction.SAMPLE_INPUT
         os.environ['DATADOG_TAGS'] = "prod:true"
         handler(ctx=None, data=to_bytes_io(payload))
-        expected_output = dict(TestLogForwarderFunction.SAMPLE_OUTPUT)
+        expected_output = dict(TestLogForwarderFunction.SAMPLE_OUTPUT[0])
         expected_output['ddtags'] = os.environ['DATADOG_TAGS']
+        expected_output = [expected_output]
         mock_post.assert_called_once()
-        self.assertDictEqual(
+        self.assertEqual(
             expected_output,
-            to_decompressed_dict(mock_post.mock_calls[0].kwargs['data'])
+            to_decompressed_data(mock_post.mock_calls[0].kwargs['data'])
         )
 
 
     @mock.patch("requests.post")
     def test_batch_format(self, mock_post):
-        """ Test batch format case, where we get an array of 'CloudEvents' """
-        batch_count = 10
-        payload = f"""
-        [
-            {",".join([TestLogForwarderFunction.SAMPLE_INPUT] * batch_count)}
-        ]
-        """
-        expected_output = [dict(TestLogForwarderFunction.SAMPLE_OUTPUT)] * batch_count
-        handler(ctx=None, data=to_bytes_io(payload))
-        self.assertEqual(batch_count, mock_post.call_count, "Data was successfully submitted for the entire batch")
-        self.assertEqual(
-            expected_output,
-            [to_decompressed_dict(arg.kwargs['data']) for arg in mock_post.call_args_list]
-        )
+        """Test batch format case, where we get an array of 'CloudEvents'."""
+        batch_counts = [10, 999, 1000, 1001, 10000]
+        for batch_count in batch_counts:
+            with self.subTest(msg=f"Batch Count: {batch_count}"):
+                mock_post.reset_mock()  # Reset mock_post before each subtest
+                payload = f"""
+                [
+                    {",".join([TestLogForwarderFunction.SAMPLE_INPUT] * batch_count)}
+                ]
+                """
+                total_calls = (batch_count + DD_BATCH_SIZE - 1) // DD_BATCH_SIZE
+                handler(ctx=None, data=to_bytes_io(payload))
+                self.assertEqual(
+                    total_calls, 
+                    mock_post.call_count, 
+                    "Data was successfully submitted for the entire batch"
+                )
+                for i in range(total_calls):
+                    call_count = DD_BATCH_SIZE if (i < total_calls - 1 or batch_count % DD_BATCH_SIZE == 0) else batch_count % DD_BATCH_SIZE
+                    expected_output = [dict(TestLogForwarderFunction.SAMPLE_OUTPUT[0])] * call_count
+                    self.assertEqual(
+                        expected_output,
+                        to_decompressed_data(mock_post.mock_calls[i].kwargs['data'])
+                    )

--- a/Service Connector  Hub/tests/test_request.py
+++ b/Service Connector  Hub/tests/test_request.py
@@ -57,15 +57,15 @@ def main():
     #Set Input data
     input_data = input_event
     if count > 1:
-        input_events = []
+        log_events = []
         for i in range(count):
             event = json.loads(input_event)
             event['data']['message'] = f"{i+1}: {event['data']['message']}"
-            input_events.append(json.dumps(event))
+            log_events.append(json.dumps(event))
 
         input_data = f"""
             [
-                {",".join(input_events)}
+                {",".join(log_events)}
             ]
             """
 

--- a/Service Connector  Hub/tests/test_request.py
+++ b/Service Connector  Hub/tests/test_request.py
@@ -8,6 +8,7 @@ import argparse
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '../')))
 
 from func import handler
+import json
 
 
 def parse_arguments():
@@ -56,11 +57,17 @@ def main():
     #Set Input data
     input_data = input_event
     if count > 1:
+        input_events = []
+        for i in range(count):
+            event = json.loads(input_event)
+            event['data']['message'] = f"{i+1}: {event['data']['message']}"
+            input_events.append(json.dumps(event))
+
         input_data = f"""
-                [
-                    {",".join([input_event] * count)}
-                ]
-                """
+            [
+                {",".join(input_events)}
+            ]
+            """
 
     # Set environment variables
     set_environment_variables(config_data)


### PR DESCRIPTION
## What

- Added DD_COMPRESS optional environment variable to specify if requests should be compressed or not. By default, they will be compressed
- Updated DATADOG_HOST variable to reflect environment, rather than the url
- Batching upto 1000 log events before calling Datadog API
- Modified test_request script to prepend message number, if producing more than 1 message, for easier testing
- Updated unit tests to account for above changes 

## Why

- DD_COMPRESS environment variable added to support benchmarking tests, with and without compression.
- Batching of events done to reduce number of API requests sent, hence reducing network traffic
- DD_HOST changes done to support expansion to multiple logs intake urls per datacenter, if needed

## Testing

1. Set DD_COMPRESS environment variable to false. Produce 1 message and ensure logs can be seen in Datadog
2. Set DD_COMPRESS environment variable to true. Produce 1 message and ensure logs can be seen in Datadog
3. Set DD_BATCH_SIZE to a small variable like 5, produced 11 messages, see all 11 in Datadog, and counted that 3 requests were made in total by printing on console
4. Logs for all cases : [Link](https://app.datadoghq.com/logs?query=source%3Aoracle_cloud%20env%3Astaging%20&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&fromUser=true&messageDisplay=inline&refresh_mode=paused&storage=hot&stream_sort=desc&viz=stream&from_ts=1728410400000&to_ts=1728412200000&live=false)