### PR TITLE
Service Connector deployed to chosen compartment with compartment specific metric namespaces

### DIFF
--- a/datadog-oci-orm/metrics-setup/data.tf
+++ b/datadog-oci-orm/metrics-setup/data.tf
@@ -20,3 +20,8 @@ data "oci_core_subnet" "input_subnet" {
   #Required
   subnet_id = var.create_vcn ? module.vcn[0].subnet_id[local.subnet] : var.function_subnet_id
 }
+
+data "oci_monitoring_metrics" "compartment_metrics" {
+  compartment_id = var.compartment_ocid
+  group_by = [ "namespace" ]
+}

--- a/datadog-oci-orm/metrics-setup/data.tf
+++ b/datadog-oci-orm/metrics-setup/data.tf
@@ -20,8 +20,3 @@ data "oci_core_subnet" "input_subnet" {
   #Required
   subnet_id = var.create_vcn ? module.vcn[0].subnet_id[local.subnet] : var.function_subnet_id
 }
-
-data "oci_monitoring_metrics" "compartment_metrics" {
-  compartment_id = var.compartment_ocid
-  group_by = [ "namespace" ]
-}

--- a/datadog-oci-orm/metrics-setup/locals.tf
+++ b/datadog-oci-orm/metrics-setup/locals.tf
@@ -9,6 +9,7 @@ locals {
 locals {
   # Names for the service connector
   connector_name = "${var.resource_name_prefix}-connector"
+  connector_metric_namespaces = ["oci_autonomous_database", "oci_blockstore", "oci_compute_infrastructure_health", "oci_computeagent", "oci_computecontainerinstance", "oci_database", "oci_database_cluster", "oci_dynamic_routing_gateway", "oci_faas", "oci_fastconnect", "oci_filestorage", "oci_gpu_infrastructure_health", "oci_lbaas", "oci_mysql_database", "oci_nat_gateway", "oci_nlb", "oci_objectstorage", "oci_oke", "oci_queue", "oci_rdma_infrastructure_health", "oci_service_connector_hub", "oci_service_gateway", "oci_vcn", "oci_vpn", "oci_waf", "oracle_oci_database"]
 }
 
 locals {

--- a/datadog-oci-orm/metrics-setup/locals.tf
+++ b/datadog-oci-orm/metrics-setup/locals.tf
@@ -9,7 +9,6 @@ locals {
 locals {
   # Names for the service connector
   connector_name = "${var.resource_name_prefix}-connector"
-  connector_metric_namespaces = ["oci_autonomous_database", "oci_blockstore", "oci_compute_infrastructure_health", "oci_computeagent", "oci_computecontainerinstance", "oci_database", "oci_database_cluster", "oci_dynamic_routing_gateway", "oci_faas", "oci_fastconnect", "oci_filestorage", "oci_gpu_infrastructure_health", "oci_lbaas", "oci_mysql_database", "oci_nat_gateway", "oci_nlb", "oci_objectstorage", "oci_oke", "oci_queue", "oci_rdma_infrastructure_health", "oci_service_connector_hub", "oci_service_gateway", "oci_vcn", "oci_vpn", "oci_waf", "oracle_oci_database"]
 }
 
 locals {

--- a/datadog-oci-orm/metrics-setup/serviceconnector.tf
+++ b/datadog-oci-orm/metrics-setup/serviceconnector.tf
@@ -15,7 +15,7 @@ resource "oci_sch_service_connector" "metrics_service_connector" {
       namespace_details {
         kind = "selected"
         dynamic "namespaces" {
-          for_each = local.connector_metric_namespaces
+          for_each = distinct(concat(local.connector_metric_namespaces, data.oci_monitoring_metrics.compartment_metrics.metrics[*].namespace))
           content {
             metrics {
               #Required

--- a/datadog-oci-orm/metrics-setup/serviceconnector.tf
+++ b/datadog-oci-orm/metrics-setup/serviceconnector.tf
@@ -15,7 +15,7 @@ resource "oci_sch_service_connector" "metrics_service_connector" {
       namespace_details {
         kind = "selected"
         dynamic "namespaces" {
-          for_each = data.oci_monitoring_metrics.compartment_metrics.metrics[*].namespace
+          for_each = local.connector_metric_namespaces
           content {
             metrics {
               #Required

--- a/datadog-oci-orm/metrics-setup/serviceconnector.tf
+++ b/datadog-oci-orm/metrics-setup/serviceconnector.tf
@@ -11,11 +11,11 @@ resource "oci_sch_service_connector" "metrics_service_connector" {
     monitoring_sources {
 
       #Optional
-      compartment_id = var.tenancy_ocid
+      compartment_id = var.compartment_ocid
       namespace_details {
         kind = "selected"
         dynamic "namespaces" {
-          for_each = local.connector_metric_namespaces
+          for_each = data.oci_monitoring_metrics.compartment_metrics.metrics[*].namespace
           content {
             metrics {
               #Required


### PR DESCRIPTION
As per Support Case: https://help.datadoghq.com/hc/en-us/requests/1893022?page=1 there max limits in the Service Connector Compartment: a maximum of 5 Compartments and a maximum metric namespace of 50. 
In this pull request instead of deploying the service connector resource to monitor the root/tenancy compartment, switch it to monitor compartment where the resources live using the data source oci_monitoring_metrics grouped by namespace to extract the supported namespaces from the chosen compartment by compartment id rather than the local.connector_metric_namespaces hardcoded input.