### PR TITLE
Fix package name

### DIFF
--- a/Service Connector  Hub/requirements.txt
+++ b/Service Connector  Hub/requirements.txt
@@ -2,4 +2,4 @@ fdk
 datetime
 requests
 oci
-yaml
+pyyaml


### PR DESCRIPTION
## What
Fix the yaml package name. The correct name is pyyaml

## Why
- https://github.com/DataDog/oracle-cloud-integration/issues/16

## Testing
- Ran pip install and tests, and works correctly