### PR TITLE
ECI-208 Add additional connector hub settings

### DIFF
--- a/datadog-oci-orm/metrics-setup/connector_namespaces.py
+++ b/datadog-oci-orm/metrics-setup/connector_namespaces.py
@@ -1,0 +1,62 @@
+import json
+import sys
+
+MAX_NAMESPACES_PER_BATCH = 50
+MAX_COMPARTMENTS_PER_BATCH = 5
+NAMESPACES_CONST = "namespaces"
+
+
+def balance_connector_hub_batches(json_string) -> None:
+  """
+  Takes an input json string which is a list of dictionary. Each dicionary having compartment id and namespace list as fields
+  and prints out json string containing batches of compartments and namespaces.
+  Example input: 
+  [
+    {"compartment": "c1": "namespaces":["n1, "n2"]}, 
+    {"compartment": "c2": "namespaces":["n1, "n2"]}, 
+    {"compartment": "c3": "namespaces":["n1, "n2"]}
+  ]
+  Prints out a json with list of batches of compartments and namespace. The maximum size based on either maximum allowed compartments in a connector hub or 
+  maximum namespaces allowed in a connector hub.
+
+  Example output: ->
+  [
+    [
+      {"compartment": "c1": "namespaces":["n1, "n2"]}, 
+      {"compartment": "c2": "namespaces":["n1, "n2"]}, 
+    ],
+    [
+      {"compartment": "c3": "namespaces":["n1, "n2"]}
+    ]
+  ]
+  """  
+  json_string = json_string.replace("\\", "")
+  compartment_namespace_list = json.loads(json_string)
+  batches, current_batch = [], []
+  batch_namespace_count = 0
+  for comp in compartment_namespace_list:
+    namespaces = comp[NAMESPACES_CONST]
+    if (len(namespaces) + batch_namespace_count) > MAX_NAMESPACES_PER_BATCH or len(current_batch) == MAX_COMPARTMENTS_PER_BATCH:
+      batches.append(current_batch)
+      batch_namespace_count = 0
+      current_batch = []
+    current_batch.append(comp)
+    batch_namespace_count += len(namespaces)
+  if current_batch:
+    batches.append(current_batch)
+  json_value = {"output" : json.dumps(batches)}
+  print(json.dumps(json_value))
+
+if __name__ == "__main__":
+    if len(sys.argv) <= 1:
+      print("No Json provided", file=sys.stderr)
+      sys.exit(1)
+    try:
+      input_json = sys.argv[1]
+      balance_connector_hub_batches(input_json)
+      sys.exit(0)
+    except ValueError as e:
+      print("Error decoding Json: ", input_json, e, file=sys.stderr)
+    except Exception as e:
+      print("Error processing namespaces", e, file=sys.stderr)
+    sys.exit(1)

--- a/datadog-oci-orm/metrics-setup/data.tf
+++ b/datadog-oci-orm/metrics-setup/data.tf
@@ -15,6 +15,17 @@ data "oci_identity_tenancy" "tenancy_metadata" {
   tenancy_id = var.tenancy_ocid
 }
 
+data "oci_identity_compartments" "tenancy_compartments" {
+  compartment_id            = var.tenancy_ocid
+  compartment_id_in_subtree = true
+}
+
+data "oci_monitoring_metrics" "existing_namespaces" {
+  for_each       = local.metrics_compartments
+  compartment_id = each.key
+  group_by       = ["namespace"]
+}
+
 data "oci_core_subnet" "input_subnet" {
   depends_on = [module.vcn]
   #Required

--- a/datadog-oci-orm/metrics-setup/function_setup.tf
+++ b/datadog-oci-orm/metrics-setup/function_setup.tf
@@ -1,5 +1,4 @@
 resource "null_resource" "Login2OCIR" {
-  count = local.user_image_provided ? 0 : 1
   provisioner "local-exec" {
     command = "echo '${var.oci_docker_password}' |  docker login ${local.oci_docker_repository} --username ${local.ocir_namespace}/${var.oci_docker_username} --password-stdin"
   }
@@ -9,7 +8,6 @@ resource "null_resource" "Login2OCIR" {
 resource "oci_artifacts_container_repository" "function_repo" {
   # note: repository = store for all images versions of a specific container image - so it included the function name
   depends_on     = [null_resource.Login2OCIR]
-  count          = local.user_image_provided ? 0 : 1
   compartment_id = var.compartment_ocid
   display_name   = "${local.ocir_repo_name}/${local.function_name}"
   is_public      = false
@@ -19,7 +17,6 @@ resource "oci_artifacts_container_repository" "function_repo" {
 
 # ### build the function into a container image and push that image to the repository in the OCI Container Image Registry
 resource "null_resource" "FnImagePushToOCIR" {
-  count      = local.user_image_provided ? 0 : 1
   depends_on = [oci_artifacts_container_repository.function_repo, oci_functions_application.metrics_function_app, null_resource.Login2OCIR]
 
   provisioner "local-exec" {

--- a/datadog-oci-orm/metrics-setup/functions.tf
+++ b/datadog-oci-orm/metrics-setup/functions.tf
@@ -30,5 +30,5 @@ resource "oci_functions_function" "metrics_function" {
   #Optional
   defined_tags  = {}
   freeform_tags = local.freeform_tags
-  image         = local.user_image_provided ? local.custom_image_path : local.docker_image_path
+  image         = local.docker_image_path
 }

--- a/datadog-oci-orm/metrics-setup/locals.tf
+++ b/datadog-oci-orm/metrics-setup/locals.tf
@@ -9,7 +9,6 @@ locals {
 locals {
   # Names for the service connector
   connector_name = "${var.resource_name_prefix}-connector"
-  connector_metric_namespaces = ["oci_autonomous_database", "oci_blockstore", "oci_compute_infrastructure_health", "oci_computeagent", "oci_computecontainerinstance", "oci_database", "oci_database_cluster", "oci_dynamic_routing_gateway", "oci_faas", "oci_fastconnect", "oci_filestorage", "oci_gpu_infrastructure_health", "oci_lbaas", "oci_mysql_database", "oci_nat_gateway", "oci_nlb", "oci_objectstorage", "oci_oke", "oci_queue", "oci_rdma_infrastructure_health", "oci_service_connector_hub", "oci_service_gateway", "oci_vcn", "oci_vpn", "oci_waf", "oracle_oci_database"]
 }
 
 locals {
@@ -37,6 +36,5 @@ locals {
   ocir_repo_name        = "${var.resource_name_prefix}-functions"
   function_name         = "datadog-function-metrics"
   docker_image_path     = "${local.oci_docker_repository}/${local.ocir_repo_name}/${local.function_name}:latest"
-  custom_image_path     = var.function_image_path
-  user_image_provided   = length(var.function_image_path) > 0 ? true : false
 }
+

--- a/datadog-oci-orm/metrics-setup/outputs.tf
+++ b/datadog-oci-orm/metrics-setup/outputs.tf
@@ -1,13 +1,5 @@
 # Output the "list" of all subscribed regions.
 
-output "all_availability_domains_in_your_tenancy" {
-  value = data.oci_identity_region_subscriptions.subscriptions.region_subscriptions
-}
-
-output "tenancy_object_storage_namespace" {
-  value = local.ocir_namespace
-}
-
 output "vcn_network_details" {
   depends_on  = [module.vcn]
   description = "Output of the created network infra"
@@ -38,7 +30,17 @@ output "function_application_function" {
   value       = oci_functions_function.metrics_function.id
 }
 
+output "compartment_map" {
+  description = "Derived namespaces"
+  value       = local.final_namespaces
+}
+
+output "namespace_error" {
+  description = "Message in case of invalid namespace"
+  value       = length(local.derived_namespaces) > 0 ? "" : "Could not obtain any namespaces or compartments for which metrics should be sent. Make sure that the provided compartments contain the resources for the supported metrics namespaces."
+}
+
 output "connector_hub" {
   description = "Connector hub created for forwarding the data to the function"
-  value       = oci_sch_service_connector.metrics_service_connector.id
+  value       = [for v in oci_sch_service_connector.metrics_service_connector : { name = v.display_name, ocid = v.id }]
 }

--- a/datadog-oci-orm/metrics-setup/schema.yaml
+++ b/datadog-oci-orm/metrics-setup/schema.yaml
@@ -6,11 +6,6 @@ schemaVersion: 1.1.0
 version: 1.0
 locale: en
 variableGroups:
-  - title: "Tenancy"
-    variables:
-      - ${tenancy_ocid}
-      - ${region}
-      - ${compartment_ocid}
   - title: "Datadog Environment"
     variables:
       - ${datadog_api_key}
@@ -21,10 +16,14 @@ variableGroups:
       - ${vcnCompartment}
       - ${existingVcn}
       - ${function_subnet_id}
+  - title: "Metrics settings"
+    variables:
+      - ${metrics_namespaces}
+      - ${metrics_compartments}
+      - ${service_connector_target_batch_size_in_kbs}
   - title: "Function settings"
     variables:
       - ${function_app_shape}
-      - ${function_image_path}
       - ${oci_docker_username}
       - ${oci_docker_password}
 
@@ -37,22 +36,47 @@ variables:
     default: datadog-metrics
   create_vcn:
     title: Create VCN
-    description: Optional variable to create virtual network for the setup. Otherwise, choose an existing subnet from VCN
+    description: Create virtual network (VCN) for the function setup. If using existing networking resources, de-select "Create VCN" and select the relevant VCN and subnet to use.
     type: boolean
     default: true
+
+  compartment_ocid:
+    # prepopulates available values for compartment
+    required: true
+    type: oci:identity:compartment:id
+    description: The compartment OCID to where this terraform stack is created and the following networking resources, function, and connecter hub will be deployed.
+    visible: false
+  region:
+    # prepopulates available values for compartment
+    required: true
+    type: string
+    visible: false
+  tenancy_ocid:
+    required: true
+    type: string
+    visible: false        
 
 # VCN
   vcnCompartment:
     # prepopulates available values for compartment
     type: oci:identity:compartment:id
+    visible:
+      not:
+        - ${create_vcn}
   existingVcn:
     type: oci:core:vcn:id
+    visible:
+      not:
+        - ${create_vcn}    
     dependsOn:
       compartmentId: ${vcnCompartment}
   function_subnet_id:
     title: Function Subnet OCID
     type: oci:core:subnet:id
-    description: The OCID of the subnet to be used for the function app. Required if not creating the VCN.
+    visible:
+      not:
+        - ${create_vcn}
+    description: The subnet to be used by the function app that will be deployed. If "Create VCN" is selected, the new VCN will overwrite this selection..
     required: false
     dependsOn:
       compartmentId: ${vcnCompartment}
@@ -80,33 +104,100 @@ variables:
       - ocimetrics-intake.ap1.datadoghq.com
     allowMultiple: false
 
+# Metrics namespace and connector hub
+  metrics_compartments:
+    title: Metrics compartments
+    type: text
+    required: true
+    description: The list of metrics compartments. Enter comma separated list of OCID of compartments to monitor.
+    default: ${tenancy_ocid}
+    multiline: true
+
+  metrics_namespaces:
+    title: Metrics namespaces
+    type: enum
+    description: The list of namespaces to send metrics for, within their respective compartments. Remove any namespaces where metrics should not be sent.
+    required: true
+    additionalProps:
+      allowMultiple: true
+    default:
+      - "oci_autonomous_database"
+      - "oci_blockstore"
+      - "oci_compute_infrastructure_health"
+      - "oci_computeagent"
+      - "oci_computecontainerinstance"
+      - "oci_database"
+      - "oci_database_cluster"
+      - "oci_dynamic_routing_gateway"
+      - "oci_faas"
+      - "oci_fastconnect"
+      - "oci_filestorage"
+      - "oci_gpu_infrastructure_health"
+      - "oci_lbaas"
+      - "oci_mysql_database"
+      - "oci_nat_gateway"
+      - "oci_nlb"
+      - "oci_objectstorage"
+      - "oci_oke"
+      - "oci_queue"
+      - "oci_rdma_infrastructure_health"
+      - "oci_service_connector_hub"
+      - "oci_service_gateway"
+      - "oci_vcn"
+      - "oci_vpn"
+      - "oci_waf"
+      - "oracle_oci_database"   
+    enum:
+      - "oci_autonomous_database"
+      - "oci_blockstore"
+      - "oci_compute_infrastructure_health"
+      - "oci_computeagent"
+      - "oci_computecontainerinstance"
+      - "oci_database"
+      - "oci_database_cluster"
+      - "oci_dynamic_routing_gateway"
+      - "oci_faas"
+      - "oci_fastconnect"
+      - "oci_filestorage"
+      - "oci_gpu_infrastructure_health"
+      - "oci_lbaas"
+      - "oci_mysql_database"
+      - "oci_nat_gateway"
+      - "oci_nlb"
+      - "oci_objectstorage"
+      - "oci_oke"
+      - "oci_queue"
+      - "oci_rdma_infrastructure_health"
+      - "oci_service_connector_hub"
+      - "oci_service_gateway"
+      - "oci_vcn"
+      - "oci_vpn"
+      - "oci_waf"
+      - "oracle_oci_database"
+    
+
   # Function setup
   function_app_shape:
     title: Function Application shape
     type: enum
-    description: The shape of the function application. The docker image should be built accordingly. Use GENERIC_ARM if using Oracle Resource managaer stack.
+    description: The shape of the function application. The docker image should be built accordingly. Use GENERIC_ARM if using Oracle Resource manager stack.
     required: true
     enum:
       - GENERIC_ARM
       - GENERIC_X86
       - GENERIC_X86_ARM
     default: GENERIC_ARM
-  function_image_path:
-    title: Function Image Path
-    type: string
-    description: The full path of the function image. The image should be present in the container registry for the region and be compatible with the function application shape.
-    required: false
   oci_docker_username:
     title: OCI Docker registry user name
     type: string
-    description: The user login for the OCI docker container registry to push function image. Not required if using an existing image path
-    required: false
+    description: The user login for the OCI docker container registry to push function image. Not required if using an existing image path.
+    required: true
     sensitive: true
   oci_docker_password:
-    title: OCI Docker registry password
+    title: OCI Docker registry auth token
     type: password
-    description: The user password for the OCI docker container registry.
-    required: false
+    description: The user auth token for the OCI docker container registry. Used in creating function image.
+    required: true
     sensitive: true
   service_connector_target_batch_size_in_kbs:
     title: Service Connector hub batch size

--- a/datadog-oci-orm/metrics-setup/serviceconnector.tf
+++ b/datadog-oci-orm/metrics-setup/serviceconnector.tf
@@ -1,27 +1,53 @@
+
+# Local variables to manage connector hubs
+locals {
+  metrics_compartments        = toset(split(",", var.metrics_compartments))
+  metrics_compartments_sorted = sort(tolist(local.metrics_compartments))
+  supported_namespaces        = var.metrics_namespaces
+  # Fetch existing namespaces from the given compartments and intersect with those supported in var.metrics_namespaces
+  compartment_tuple = [for comp in local.metrics_compartments_sorted : { compartment = comp, namespaces = tolist(setintersection(local.supported_namespaces, [for ns in data.oci_monitoring_metrics.existing_namespaces[comp].metrics : ns.namespace])) }]
+  # Filter out the compartments having no namespaces to monitor. Each tuple having compartment id and list of namespaces.
+  derived_namespaces = [for tup in local.compartment_tuple : tup if length(tup.namespaces) > 0]
+
+  # Convert to json string.
+  derived_namespaces_str = jsonencode(local.derived_namespaces)
+
+  # Final balanced batches of compartments obtained from the script in data.external.connector_namespace_distribution.
+  final_namespaces = jsondecode(data.external.connector_namespace_distribution.result.output)
+}
+
+
+# external script to balance the compartments and their namespaces. Returns a batch based on which connector hubs are created.
+data "external" "connector_namespace_distribution" {
+  program = ["python", "${path.module}/connector_namespaces.py", "${local.derived_namespaces_str}"]
+}
+
 resource "oci_sch_service_connector" "metrics_service_connector" {
+  for_each   = { for i in range(0, length(local.final_namespaces)) : i => local.final_namespaces[i] }
   depends_on = [oci_functions_function.metrics_function]
   #Required
   compartment_id = var.compartment_ocid
-  display_name   = local.connector_name
+  display_name   = "${local.connector_name}-${each.key}"
   source {
     #Required
     kind = "monitoring"
 
     #Optional
-    monitoring_sources {
-
-      #Optional
-      compartment_id = var.tenancy_ocid
-      namespace_details {
-        kind = "selected"
-        dynamic "namespaces" {
-          for_each = local.connector_metric_namespaces
-          content {
-            metrics {
-              #Required
-              kind = "all"
+    dynamic "monitoring_sources" {
+      for_each = each.value
+      content {
+        compartment_id = monitoring_sources.value.compartment
+        namespace_details {
+          kind = "selected"
+          dynamic "namespaces" {
+            for_each = monitoring_sources.value.namespaces
+            content {
+              metrics {
+                #Required
+                kind = "all"
+              }
+              namespace = namespaces.value
             }
-            namespace = namespaces.value
           }
         }
       }

--- a/datadog-oci-orm/metrics-setup/variables.tf
+++ b/datadog-oci-orm/metrics-setup/variables.tf
@@ -7,7 +7,7 @@ variable "resource_name_prefix" {
 variable "create_vcn" {
   type        = bool
   default     = true
-  description = "Optional variable to create virtual network for the setup. True by default"
+  description = "Variable to create virtual network for the setup. True by default"
 }
 
 variable "datadog_api_key" {
@@ -18,18 +18,13 @@ variable "datadog_api_key" {
 variable "function_subnet_id" {
   type        = string
   default     = ""
-  description = "The OCID of the subnet to be used for the function app. Required if not creating the VCN"
+  description = "The OCID of the subnet to be used for the function app. If create_vcn is set to true, that will take precedence"
 }
 
-variable "function_image_path" {
-  type        = string
-  default     = ""
-  description = "The full path of the function image. The image should be present in the container registry for the region"
-}
 variable "function_app_shape" {
   type        = string
   default     = "GENERIC_ARM"
-  description = "The shape of the function application. The docker image should be built accordingly. Use ARM if using Oracle Resource managaer stack"
+  description = "The shape of the function application. The docker image should be built accordingly. Use ARM if using Oracle Resource manager stack"
   validation {
     condition     = contains(["GENERIC_ARM", "GENERIC_X86", "GENERIC_X86_ARM"], var.function_app_shape)
     error_message = "Valid values are: GENERIC_ARM, GENERIC_X86, GENERIC_X86_ARM."
@@ -48,22 +43,31 @@ variable "datadog_environment" {
 
 variable "oci_docker_username" {
   type        = string
-  default     = ""
   sensitive   = true
   description = "The docker login username for the OCI container registry. Used in creating function image. Not required if the image is already exists."
 }
 
 variable "oci_docker_password" {
   type        = string
-  default     = ""
   sensitive   = true
-  description = "The auth password for docker login to OCI container registry. Used in creating function image. Not required if the image already exists."
+  description = "The user auth token for the OCI docker container registry. Used in creating function image. Not required if the image already exists."
 }
 
 variable "service_connector_target_batch_size_in_kbs" {
   type        = string
   description = "The batch size (in Kb) in which to send payload to target"
   default     = "5000"
+}
+
+variable "metrics_namespaces" {
+  type        = list(string)
+  description = "The list of namespaces to collect the metrics for the metrics compartments. Remove any unwanted namespaces."
+  default     = ["oci_autonomous_database", "oci_blockstore", "oci_compute_infrastructure_health", "oci_computeagent", "oci_computecontainerinstance", "oci_database", "oci_database_cluster", "oci_dynamic_routing_gateway", "oci_faas", "oci_fastconnect", "oci_filestorage", "oci_gpu_infrastructure_health", "oci_lbaas", "oci_mysql_database", "oci_nat_gateway", "oci_nlb", "oci_objectstorage", "oci_oke", "oci_queue", "oci_rdma_infrastructure_health", "oci_service_connector_hub", "oci_service_gateway", "oci_vcn", "oci_vpn", "oci_waf", "oracle_oci_database"]
+}
+
+variable "metrics_compartments" {
+  type        = string
+  description = "The comma separated list of compartments OCID to collect metrics."
 }
 
 #*************************************
@@ -73,6 +77,7 @@ variable "tenancy_ocid" {
   type        = string
   description = "OCI tenant OCID, more details can be found at https://docs.cloud.oracle.com/en-us/iaas/Content/API/Concepts/apisigningkey.htm#five"
 }
+
 variable "region" {
   type        = string
   description = "OCI Region as documented at https://docs.cloud.oracle.com/en-us/iaas/Content/General/Concepts/regions.htm"
@@ -81,4 +86,3 @@ variable "compartment_ocid" {
   type        = string
   description = "The compartment OCID to deploy resources to"
 }
-


### PR DESCRIPTION
**what:**
* Add additional settings for connector hub.
* While running the terraform stacks, provides additional options:
    - Comma separated list of compartment ids
    - List of namespaces to include. 
    - The final list of namespaces in each compartment is an intersection of existing metrics namespaces in that compartment and the selected namespaces.

**why:**
* For better customer experience of adding additional compartments and not just root compartmen

**testing:**
The existing stack can be [seen here](https://cloud.oracle.com/resourcemanager/privateTemplateProviders/ocid1.ormtemplate.oc1.iad.amaaaaaaehwejaiazepd7rxtbgjxt6qh6qhlp37yomwvwgaqfdg6ctpx3btq?region=us-ashburn-1)