### PR TITLE
ECI-414 [OCI] Add options for auth token and service user inputs for metric stack

### DIFF
--- a/datadog-oci-orm/metrics-setup/data.tf
+++ b/datadog-oci-orm/metrics-setup/data.tf
@@ -31,3 +31,8 @@ data "oci_core_subnet" "input_subnet" {
   #Required
   subnet_id = var.create_vcn ? module.vcn[0].subnet_id[local.subnet] : var.function_subnet_id
 }
+
+data "oci_identity_user" "docker_user" {
+    #Required
+    user_id = local.user_ocid
+}

--- a/datadog-oci-orm/metrics-setup/function_setup.tf
+++ b/datadog-oci-orm/metrics-setup/function_setup.tf
@@ -56,7 +56,7 @@ resource "null_resource" "Login2OCIR" {
           fi
 
            for i in {1..5}; do
-               echo "${var.auth_token}" | docker login ${local.registry_domain} --username ${local.ocir_namespace}/${local.username} --password-stdin && break
+               echo "$auth_token" | docker login ${local.registry_domain} --username ${local.ocir_namespace}/${local.username} --password-stdin && break
                echo "Retrying Docker login... attempt $i"
                sleep 10
            done
@@ -65,7 +65,7 @@ resource "null_resource" "Login2OCIR" {
            if [ $i -eq 5 ]; then
                echo "Error: Docker login failed after 5 attempts. Trying to login through Oracle Identity Cloud Service"
                for j in {1..5}; do
-                   echo "${var.auth_token}" | docker login ${local.registry_domain} --username ${local.ocir_namespace}/oracleidentitycloudservice/$username --password-stdin && break
+                   echo "$auth_token" | docker login ${local.registry_domain} --username ${local.ocir_namespace}/oracleidentitycloudservice/$username --password-stdin && break
                    echo "Retrying Docker login through Identity service... attempt $j"
                    sleep 5
                done

--- a/datadog-oci-orm/metrics-setup/function_setup.tf
+++ b/datadog-oci-orm/metrics-setup/function_setup.tf
@@ -1,11 +1,62 @@
+resource "null_resource" "recreate_auth_token" {
+    count = "${var.auth_token != "" ? 0 : 1}"
+    provisioner "local-exec" {
+        command = <<EOT
+            #!/bin/bash
+            set -e
+
+            # Step 1: List existing auth tokens
+            echo "Listing existing auth tokens..."
+            existing_token_ocid=$(oci iam auth-token list --user-id ${local.user_ocid} \
+                --query "data[?description=='${var.auth_token_description}'].id | [0]" --raw-output)
+
+            if [ "$existing_token_ocid" != "" ]; then
+                echo "Deleting existing auth token: $existing_token_ocid"
+                oci iam auth-token delete --user-id ${local.user_ocid} --auth-token-id $existing_token_ocid --force
+            else
+                # Check the total number of existing tokens
+                total_tokens=$(oci iam auth-token list --user-id ${local.user_ocid} --query "length(data)" --raw-output)
+
+                if [ "$total_tokens" -eq 2 ]; then
+                    echo "Error: Total existing tokens are equal to 2. Cannot create a new token."
+                    exit 1
+                fi
+                echo "No existing auth token with description '${var.auth_token_description}' found. Proceeding to create a new one."
+            fi
+
+            # Step 2: Create a new auth token
+            echo "Creating a new auth token..."
+            new_token_value=$(oci iam auth-token create --user-id ${local.user_ocid} \
+                --description "${var.auth_token_description}" --query "data.token" --raw-output)
+
+            # Step 3: Sleep for 30 seconds to ensure token propagation
+            echo "Waiting for 60 seconds to ensure token availability..."
+            sleep 60
+
+            echo $new_token_value > /tmp/new_auth_token.txt
+        EOT
+    }
+    triggers = {
+        always_run = "${timestamp()}"
+    }
+}
+
 resource "null_resource" "Login2OCIR" {
+   depends_on = [null_resource.recreate_auth_token]
    provisioner "local-exec" {
        command = <<EOT
            #!/bin/bash
            set -e
 
+           # Run the current command
+          if [ "${var.auth_token}" != "" ]; then
+              auth_token="${var.auth_token}"
+          else
+              auth_token=$(cat /tmp/new_auth_token.txt && rm -f /tmp/new_auth_token.txt)
+          fi
+
            for i in {1..5}; do
-               echo "${var.oci_docker_password}" | docker login ${local.oci_docker_repository} --username ${local.ocir_namespace}/${var.oci_docker_username} --password-stdin && break
+               echo "${var.auth_token}" | docker login ${local.registry_domain} --username ${local.ocir_namespace}/${local.username} --password-stdin && break
                echo "Retrying Docker login... attempt $i"
                sleep 10
            done
@@ -14,7 +65,7 @@ resource "null_resource" "Login2OCIR" {
            if [ $i -eq 5 ]; then
                echo "Error: Docker login failed after 5 attempts. Trying to login through Oracle Identity Cloud Service"
                for j in {1..5}; do
-                   echo "${var.oci_docker_password}" | docker login ${local.oci_docker_repository} --username ${local.ocir_namespace}/oracleidentitycloudservice/$username --password-stdin && break
+                   echo "${var.auth_token}" | docker login ${local.registry_domain} --username ${local.ocir_namespace}/oracleidentitycloudservice/$username --password-stdin && break
                    echo "Retrying Docker login through Identity service... attempt $j"
                    sleep 5
                done
@@ -44,6 +95,10 @@ resource "oci_artifacts_container_repository" "function_repo" {
 # ### build the function into a container image and push that image to the repository in the OCI Container Image Registry
 resource "null_resource" "FnImagePushToOCIR" {
   depends_on = [oci_artifacts_container_repository.function_repo, oci_functions_application.metrics_function_app, null_resource.Login2OCIR]
+
+  provisioner "local-exec" {
+    command = "echo '${var.auth_token}' |  docker login ${local.oci_docker_repository} --username ${local.ocir_namespace}/${local.username} --password-stdin"
+  }
 
   # remove function image (if it exists) from local container registry
   provisioner "local-exec" {

--- a/datadog-oci-orm/metrics-setup/locals.tf
+++ b/datadog-oci-orm/metrics-setup/locals.tf
@@ -27,6 +27,7 @@ locals {
   })
   oci_region_key      = lower(local.oci_regions[var.region].region_key)
   tenancy_home_region = data.oci_identity_tenancy.tenancy_metadata.home_region_key
+  user_ocid = var.service_user_ocid == "" ? var.current_user_ocid : var.service_user_ocid
 }
 
 locals {
@@ -36,5 +37,7 @@ locals {
   ocir_repo_name        = "${var.resource_name_prefix}-functions"
   function_name         = "datadog-function-metrics"
   docker_image_path     = "${local.oci_docker_repository}/${local.ocir_repo_name}/${local.function_name}:latest"
+  username = data.oci_identity_user.docker_user.name
+  registry_domain = "ocir.${var.region}.oci.oraclecloud.com"
 }
 

--- a/datadog-oci-orm/metrics-setup/outputs.tf
+++ b/datadog-oci-orm/metrics-setup/outputs.tf
@@ -44,3 +44,12 @@ output "connector_hub" {
   description = "Connector hub created for forwarding the data to the function"
   value       = [for v in oci_sch_service_connector.metrics_service_connector : { name = v.display_name, ocid = v.id }]
 }
+
+output "containerregistry_details" {
+  description = "Output of pushing image to container registry"
+  value       = {
+    repository_ocid = oci_artifacts_container_repository.function_repo.id
+    repository_name = oci_artifacts_container_repository.function_repo.display_name
+    function_image_path = "${local.docker_image_path}:latest"
+  }
+}

--- a/datadog-oci-orm/metrics-setup/schema.yaml
+++ b/datadog-oci-orm/metrics-setup/schema.yaml
@@ -24,8 +24,13 @@ variableGroups:
   - title: "Function settings"
     variables:
       - ${function_app_shape}
-      - ${oci_docker_username}
-      - ${oci_docker_password}
+  - title: "Container Registry"
+    variables:
+      - ${use_different_service_user}
+      - ${service_user_ocid}
+      - ${create_auth_token}
+      - ${auth_token_description}
+      - ${auth_token}
 
 variables:
   resource_name_prefix:
@@ -54,7 +59,11 @@ variables:
   tenancy_ocid:
     required: true
     type: string
-    visible: false        
+    visible: false
+  current_user_ocid:
+    required: true
+    type: string
+    visible: false
 
 # VCN
   vcnCompartment:
@@ -67,7 +76,7 @@ variables:
     type: oci:core:vcn:id
     visible:
       not:
-        - ${create_vcn}    
+        - ${create_vcn}
     dependsOn:
       compartmentId: ${vcnCompartment}
   function_subnet_id:
@@ -146,7 +155,7 @@ variables:
       - "oci_vcn"
       - "oci_vpn"
       - "oci_waf"
-      - "oracle_oci_database"   
+      - "oracle_oci_database"
     enum:
       - "oci_autonomous_database"
       - "oci_blockstore"
@@ -174,7 +183,6 @@ variables:
       - "oci_vpn"
       - "oci_waf"
       - "oracle_oci_database"
-    
 
   # Function setup
   function_app_shape:
@@ -187,21 +195,52 @@ variables:
       - GENERIC_X86
       - GENERIC_X86_ARM
     default: GENERIC_ARM
-  oci_docker_username:
-    title: OCI Docker registry user name
-    type: string
-    description: The user login for the OCI docker container registry to push function image. Not required if using an existing image path.
-    required: true
-    sensitive: true
-  oci_docker_password:
-    title: OCI Docker registry auth token
-    type: password
-    description: The user auth token for the OCI docker container registry. Used in creating function image.
-    required: true
-    sensitive: true
   service_connector_target_batch_size_in_kbs:
     title: Service Connector hub batch size
     type: nonNegativeInteger
     description: The batch size (in Kb) in which to send payload to target.
     required: false
     default: 5000
+
+
+# Container registry
+  use_different_service_user:
+    title: Use Different Service User
+    description: Option to use a different service user for Docker login and pushing images.
+    type: boolean
+    required: true
+    default: false
+
+  service_user_ocid:
+    title: Service User OCID
+    type: string
+    description: The OCID of the service user to be used for Docker login and pushing images.
+    required: true
+    default: ""
+    visible: ${use_different_service_user}
+
+  create_auth_token:
+    title: Create Auth Token
+    description: Variable to create auth token for the user. Otherwise, choose an existing auth token. If there are already 2 tokens, you need to delete one to create a new one.
+    type: boolean
+    required: true
+    default: false
+    visible:
+      not:
+        - ${use_different_service_user}
+
+  auth_token_description:
+    title: Auth Token Description
+    default: datadog-auth-token
+    required: true
+    visible: ${create_auth_token}
+
+  auth_token:
+    title: OCI Docker registry auth token
+    type: password
+    description: The user auth token for the OCI docker container registry. Used in creating function image.
+    required: true
+    sensitive: true
+    visible:
+      not:
+        - ${create_auth_token}

--- a/datadog-oci-orm/metrics-setup/variables.tf
+++ b/datadog-oci-orm/metrics-setup/variables.tf
@@ -15,22 +15,6 @@ variable "datadog_api_key" {
   description = "The API key for sending message to datadog endpoints"
 }
 
-variable "function_subnet_id" {
-  type        = string
-  default     = ""
-  description = "The OCID of the subnet to be used for the function app. If create_vcn is set to true, that will take precedence"
-}
-
-variable "function_app_shape" {
-  type        = string
-  default     = "GENERIC_ARM"
-  description = "The shape of the function application. The docker image should be built accordingly. Use ARM if using Oracle Resource manager stack"
-  validation {
-    condition     = contains(["GENERIC_ARM", "GENERIC_X86", "GENERIC_X86_ARM"], var.function_app_shape)
-    error_message = "Valid values are: GENERIC_ARM, GENERIC_X86, GENERIC_X86_ARM."
-  }
-}
-
 variable "datadog_environment" {
   type        = string
   description = "The endpoint to hit for sending the metrics. Varies by different datacenter"
@@ -39,18 +23,6 @@ variable "datadog_environment" {
     "ocimetrics-intake.datadoghq.eu", "ocimetrics-intake.ap1.datadoghq.com", "ocimetrics-intake.ddog-gov.com"], var.datadog_environment)
     error_message = "Valid values for var: datadog_environment are (ocimetrics-intake.datadoghq.com, ocimetrics-intake.us5.datadoghq.com, ocimetrics-intake.us3.datadoghq.com, ocimetrics-intake.datadoghq.eu, ocimetrics-intake.ap1.datadoghq.com, ocimetrics-intake.ddog-gov.com)."
   }
-}
-
-variable "oci_docker_username" {
-  type        = string
-  sensitive   = true
-  description = "The docker login username for the OCI container registry. Used in creating function image. Not required if the image is already exists."
-}
-
-variable "oci_docker_password" {
-  type        = string
-  sensitive   = true
-  description = "The user auth token for the OCI docker container registry. Used in creating function image. Not required if the image already exists."
 }
 
 variable "service_connector_target_batch_size_in_kbs" {
@@ -70,6 +42,26 @@ variable "metrics_compartments" {
   description = "The comma separated list of compartments OCID to collect metrics."
 }
 
+#************************************
+#   Function Application Variables
+#************************************
+
+variable "function_subnet_id" {
+  type        = string
+  default     = ""
+  description = "The OCID of the subnet to be used for the function app. If create_vcn is set to true, that will take precedence"
+}
+
+variable "function_app_shape" {
+  type        = string
+  default     = "GENERIC_ARM"
+  description = "The shape of the function application. The docker image should be built accordingly. Use ARM if using Oracle Resource manager stack"
+  validation {
+    condition     = contains(["GENERIC_ARM", "GENERIC_X86", "GENERIC_X86_ARM"], var.function_app_shape)
+    error_message = "Valid values are: GENERIC_ARM, GENERIC_X86, GENERIC_X86_ARM."
+  }
+}
+
 #*************************************
 #         TF auth Requirements
 #*************************************
@@ -85,4 +77,31 @@ variable "region" {
 variable "compartment_ocid" {
   type        = string
   description = "The compartment OCID to deploy resources to"
+}
+
+variable "current_user_ocid" {
+  type        = string
+  description = "OCID of the logged in user"
+}
+
+#************************************
+#    Container Registry Variables
+#************************************
+variable "auth_token_description" {
+  description = "The description of the auth token to use for container registry login"
+  type        = string
+  default     = "datadog-auth-token"
+}
+
+variable "auth_token" {
+  type        = string
+  default     = ""
+  sensitive   = true
+  description = "The user auth token for docker login to OCI container registry."
+}
+
+variable "service_user_ocid" {
+  type        = string
+  default     = ""
+  description = "The OCID of the service user to be used for Docker login and pushing images."
 }


### PR DESCRIPTION
**what:**
Add “Use Different Service User” boolean option to support letting customers choose a different user for container registry interaction.

Add “Create Auth Token” boolean option to auto-create a token for the logged in user, to support simplicity.
**why:**
Enable customers to run the stack completely from ORM UI, without jumping around multiple screens

**testing:**

- [x] test logged in user success
- [x] test create auth token success
- [ ] test use different service user success