### PR TITLE
ECI-418 Fix the policy setup on removing domain name variable

### DIFF
--- a/datadog-oci-orm/policy-setup/policy.tf
+++ b/datadog-oci-orm/policy-setup/policy.tf
@@ -75,7 +75,7 @@ resource "oci_identity_policy" "metrics_policy" {
   statements = ["Allow dynamic-group ${var.dynamic_group_name} to read metrics in tenancy",
     "Allow dynamic-group ${var.dynamic_group_name} to use fn-function in tenancy",
     "Allow dynamic-group ${var.dynamic_group_name} to use fn-invocation in tenancy",
-    "Allow group ${var.user_domain}/${oci_identity_group.read_policy_group.name} to read all-resources in tenancy"
+    "Allow group Default/${oci_identity_group.read_policy_group.name} to read all-resources in tenancy"
   ]
   defined_tags  = {}
   freeform_tags = local.freeform_tags

--- a/datadog-oci-orm/policy-setup/variables.tf
+++ b/datadog-oci-orm/policy-setup/variables.tf
@@ -28,10 +28,4 @@ variable "datadog_metrics_policy" {
   default     = "datadog-metrics-policy"
 }
 
-variable "user_domain" {
-  type        = string
-  description = "The name of the domain where the operation is to be run. By default the users and groups will be created in the domain of the current user running the setup. If the user running this setup does not belong to the Default domain, enter the domain name they belong to here."
-  default     = "Default"
-}
-
 


### PR DESCRIPTION
**what:**
Remove the Domain name from the policy stack

**why:**
* By default, the user and groups and created in the Default domain which makes this option redundant.