### PR TITLE
ECI [OCI] include more log attributes and assign "DD_SOURCE" based on OCI service

### DIFF
--- a/datadog-logs-oci-orm/logs-function/func.py
+++ b/datadog-logs-oci-orm/logs-function/func.py
@@ -7,7 +7,7 @@ import requests
 
 logger = logging.getLogger(__name__)
 
-DD_SOURCE = "OCI Logs"  # Adding a source default name. The source will be mapped to the log's respective service to be processed by the correct pipeline in Datadog. 
+DD_SOURCE = "oci.logs"  # Adding a source default name. The source will be mapped to the log's respective service to be processed by the correct pipeline in Datadog. 
 DD_SERVICE = "oci"  # Adding a service name.
 DD_TIMEOUT = 10 * 60  # Adding a timeout for the Datadog API call.
 DD_BATCH_SIZE = 1000  # Adding a batch size for the Datadog API call.

--- a/datadog-logs-oci-orm/logs-function/func.py
+++ b/datadog-logs-oci-orm/logs-function/func.py
@@ -7,7 +7,7 @@ import requests
 
 logger = logging.getLogger(__name__)
 
-DD_SOURCE = "oci.logs"  # Adding a source default name. The source will be mapped to the log's respective service to be processed by the correct pipeline in Datadog. 
+DD_SOURCE = "oci.logs"  # Adding a source default name. The source will be mapped to the log's respective service to be processed by the correct pipeline in Datadog.
 DD_SERVICE = "oci"  # Adding a service name.
 DD_TIMEOUT = 10 * 60  # Adding a timeout for the Datadog API call.
 DD_BATCH_SIZE = 1000  # Adding a batch size for the Datadog API call.
@@ -31,10 +31,10 @@ def _process(body: list[dict]) -> None:
     This function retrieves the Datadog endpoint URL and token from environment variables,
     processes each log entry in the provided list, compresses the payload, and sends it
     to the Datadog API.
-    
+
     Args:
         body (list[dict]): A list of log entries, where each log entry is represented as a dictionary.
-    
+
     Raises:
         KeyError: If the required environment variables 'DATADOG_HOST' or 'DATADOG_TOKEN' are not set.
         Exception: If there is an error during the API request or payload processing.
@@ -75,25 +75,25 @@ def _get_oci_source_name(body: dict) -> str:
     """
     Returns the source name for the log entry.
     This function determines if the log is an Audit log, and if not, what source it is coming from .
-    
+
     Args:
         body (dict): A log entry represented as a dictionary.
-    
+
     Returns:
         str: The source name for the log entry.
     """
     oracle = body.get("oracle")
     logtype = body.get("type")
 
-    if oracle.get("loggroupid") != None and oracle.get("loggroupid") == "_Audit":
+    if oracle != None and oracle.get("loggroupid") != None and oracle.get("loggroupid") == "_Audit":
         return "oci.audit"
 
-    if logtype != "":
+    if logtype != None and logtype != "":
         # logtype is of format com.oraclecloud.{service}.{resource-type}.{category}
         split_logtype = logtype.split(".")
         if len(split_logtype) >= 3:
             return "oci." + split_logtype[2]
-    
+
     return DD_SOURCE
 
 def _process_single_log(body: dict) -> dict:

--- a/datadog-logs-oci-orm/logs-function/func.py
+++ b/datadog-logs-oci-orm/logs-function/func.py
@@ -90,7 +90,9 @@ def _get_oci_source_name(body: dict) -> str:
 
     if logtype != "":
         # logtype is of format com.oraclecloud.{service}.{resource-type}.{category}
-        return "oci." + logtype.split(".")[2]
+        split_logtype = logtype.split(".")
+        if len(split_logtype) >= 3:
+            return "oci." + split_logtype[2]
     
     return DD_SOURCE
 

--- a/datadog-logs-oci-orm/logs-function/func.py
+++ b/datadog-logs-oci-orm/logs-function/func.py
@@ -7,8 +7,8 @@ import requests
 
 logger = logging.getLogger(__name__)
 
-DD_SOURCE = "oracle_cloud"  # Adding a source name.
-DD_SERVICE = "OCI Logs"  # Adding a service name.
+DD_SOURCE = "OCI Logs"  # Adding a source default name. The source will be mapped to the log's respective service to be processed by the correct pipeline in Datadog. 
+DD_SERVICE = "oci"  # Adding a service name.
 DD_TIMEOUT = 10 * 60  # Adding a timeout for the Datadog API call.
 DD_BATCH_SIZE = 1000  # Adding a batch size for the Datadog API call.
 
@@ -71,6 +71,28 @@ def _process(body: list[dict]) -> None:
     except Exception as ex:
         logger.exception(ex)
 
+def _get_oci_source_name(body: dict) -> str:
+    """
+    Returns the source name for the log entry.
+    This function determines if the log is an Audit log, and if not, what source it is coming from .
+    
+    Args:
+        body (dict): A log entry represented as a dictionary.
+    
+    Returns:
+        str: The source name for the log entry.
+    """
+    oracle = body.get("oracle")
+    logtype = body.get("type")
+
+    if oracle.get("loggroupid") != None and oracle.get("loggroupid") == "_Audit":
+        return "oci.audit"
+
+    if logtype != "":
+        # logtype is of format com.oraclecloud.{service}.{resource-type}.{category}
+        return "oci." + logtype.split(".")[2]
+    
+    return DD_SOURCE
 
 def _process_single_log(body: dict) -> dict:
     data = body.get("data", {})
@@ -78,12 +100,13 @@ def _process_single_log(body: dict) -> dict:
     time = body.get("time")
     logtype = body.get("type")
     oracle = body.get("oracle")
+    ddsource = _get_oci_source_name(body)
 
     payload = {
         "source": source,
         "timestamp": time,
         "data": data,
-        "ddsource": DD_SOURCE,
+        "ddsource": ddsource,
         "service": DD_SERVICE,
         "type": logtype,
         "oracle": oracle

--- a/datadog-logs-oci-orm/logs-function/func.py
+++ b/datadog-logs-oci-orm/logs-function/func.py
@@ -76,6 +76,8 @@ def _process_single_log(body: dict) -> dict:
     data = body.get("data", {})
     source = body.get("source")
     time = body.get("time")
+    logtype = body.get("type")
+    oracle = body.get("oracle")
 
     payload = {
         "source": source,
@@ -83,6 +85,8 @@ def _process_single_log(body: dict) -> dict:
         "data": data,
         "ddsource": DD_SOURCE,
         "service": DD_SERVICE,
+        "type": logtype,
+        "oracle": oracle
     }
 
     dd_tags = os.environ.get('DATADOG_TAGS', '')


### PR DESCRIPTION
We need to forward the "oracle" and "type" attributes from OCI logs to get all the information for facets.
Also, we need to be able to distinguish what type of log we are sending from OCI to dd, so this PR checks if the log is a service log. If it is not, it extracts the service name from the "type" attribute.