### PR TITLE
[ECI-396] Add logging module

### DIFF
--- a/datadog-logs-oci-orm/data.tf
+++ b/datadog-logs-oci-orm/data.tf
@@ -1,3 +1,26 @@
 data "external" "logging_services" {
     program = ["bash", "logging_services.sh"]
 }
+
+# Step 1: Fetch all compartments in the tenancy
+data "oci_identity_compartments" "all_compartments" {
+  compartment_id = var.tenancy_ocid
+  state = "ACTIVE"
+}
+
+# Step 2: Fetch all log groups in each compartment
+data "oci_logging_log_groups" "log_groups_by_compartment" {
+  for_each       = toset([for compartment in data.oci_identity_compartments.all_compartments.compartments : compartment.id])
+  compartment_id = each.value
+}
+
+locals {
+  flat_log_groups = flatten([
+    for compartment_id, log_group_data in data.oci_logging_log_groups.log_groups_by_compartment : log_group_data.log_groups
+  ])
+}
+# Step 3: Fetch all logs in each log group
+data "oci_logging_logs" "logs_by_log_group" {
+  for_each = toset([for log_group in local.flat_log_groups : log_group.id])
+  log_group_id = each.value
+}

--- a/datadog-logs-oci-orm/data.tf
+++ b/datadog-logs-oci-orm/data.tf
@@ -1,26 +1,3 @@
 data "external" "logging_services" {
     program = ["bash", "logging_services.sh"]
 }
-
-# Step 1: Fetch all compartments in the tenancy
-data "oci_identity_compartments" "all_compartments" {
-  compartment_id = var.tenancy_ocid
-  state = "ACTIVE"
-}
-
-# Step 2: Fetch all log groups in each compartment
-data "oci_logging_log_groups" "log_groups_by_compartment" {
-  for_each       = toset([for compartment in data.oci_identity_compartments.all_compartments.compartments : compartment.id])
-  compartment_id = each.value
-}
-
-locals {
-  flat_log_groups = flatten([
-    for compartment_id, log_group_data in data.oci_logging_log_groups.log_groups_by_compartment : log_group_data.log_groups
-  ])
-}
-# Step 3: Fetch all logs in each log group
-data "oci_logging_logs" "logs_by_log_group" {
-  for_each = toset([for log_group in local.flat_log_groups : log_group.id])
-  log_group_id = each.value
-}

--- a/datadog-logs-oci-orm/locals.tf
+++ b/datadog-logs-oci-orm/locals.tf
@@ -32,7 +32,59 @@ locals {
       }
     ]
   ])
+}
 
+locals {
+  # Combine and group resources by compartment ID (may still contain nested lists)
+  compartment_resources = {
+    for compartment_group, resources in module.resourcediscovery :
+    split("_", compartment_group)[0] => resources.response...
+    if length(resources.response) > 0
+  }
+}
+
+locals {
+  /*
+    This code snippet processes a list of filtered services to create a mapping of service IDs and resource types to their corresponding categories.
+
+    Steps:
+    1. Flatten the `filtered_services` list to create `service_resource_type_list`, which contains objects with combined service ID and resource type as the key, and a list of category names as the value.
+    2. Create `service_category_map` using `zipmap`, where the keys are the combined service ID and resource type, and the values are the lists of category names.
+    3. Transform `service_category_map` into `transformed_service_map`, where if any category name starts with "all", only those categories are kept; otherwise, all categories are kept.
+
+    Input:
+    local.filtered_services = [
+      {
+        id = "service1",
+        resourceTypes = [
+          {
+            name = "type1",
+            categories = ["cat1", "all-cat2"]
+          },
+          {
+            name = "type2",
+            categories = ["cat3"]
+          }
+        ]
+      },
+      {
+        id = "service2",
+        resourceTypes = [
+          {
+            name = "type3",
+            categories = ["all-cat4", "cat5"]
+          }
+        ]
+      }
+    ]
+
+    Output:
+    local.service_map = {
+      "service1_type1" = ["all-cat2"],
+      "service1_type2" = ["cat3"],
+      "service2_type3" = ["all-cat4"]
+    }
+  */
   # Flatten filtered_services to get service_id_resource_type and corresponding categories
   service_resource_type_list = flatten([
     for service in local.filtered_services : [
@@ -48,13 +100,45 @@ locals {
     [for item in local.service_resource_type_list : item.key],        # Keys: service_id_resource_type
     [for item in local.service_resource_type_list : item.categories] # Values: category name lists
   )
+
+  service_map = tomap({
+    for key, values in local.service_category_map : 
+    key => (
+      length([for value in values : value if startswith(value, "all")]) > 0 ? 
+      [for value in values : value if startswith(value, "all")] : 
+      values
+    )
+  })
 }
 
 locals {
-  # Combine and group resources by compartment ID (may still contain nested lists)
-  compartment_resources = {
-    for compartment_group, resources in module.resourcediscovery :
-    split("_", compartment_group)[0] => resources.response...
-    if length(resources.response) > 0
-  }
+    allowed_service_ids = [for key, value in local.service_map : split("_", key)[0]]
+    filtered_logs = flatten([
+        for log_group in data.oci_logging_logs.logs_by_log_group : [
+            for log in log_group.logs :
+            # Filter logs based on the allowed_services variable
+            {
+                log_group_ocid  = log.log_group_id
+                #log_ocid       = log.id
+                state           = log.state
+                #log_type       = log.log_type
+                compartment_id  = log.compartment_id
+                is_enabled      = log.is_enabled
+                resource_id     = try(log.configuration[0].source[0].resource, null)
+                service_id      = try(log.configuration[0].source[0].service, null)
+                category        = try(log.configuration[0].source[0].category, null)
+            } if contains(local.allowed_service_ids, try(log.configuration[0].source[0].service, ""))
+        ]
+    ])
+
+    # Map for resourceId_service_category => [{loggroupid, state, is_enabled}]
+    logs_map = tomap({
+        for log in local.filtered_logs : 
+        "${log.resource_id}_${log.service_id}_${log.category}" => {
+            loggroupid = log.log_group_ocid
+            state      = log.state
+            is_enabled = log.is_enabled
+            compartmentid = log.compartment_id
+        }
+    })
 }

--- a/datadog-logs-oci-orm/locals.tf
+++ b/datadog-logs-oci-orm/locals.tf
@@ -10,8 +10,17 @@ locals {
   logging_csv_content = base64decode(var.logging_compartments_csv)
   logging_compartments = csvdecode(local.logging_csv_content)
 
-  # Extract only the compartment IDs into a list
-  logging_compartment_ids = [for row in local.logging_compartments : row.compartment_id]
+  logging_configurations = {
+    for row in local.logging_compartments :
+    row.compartment_id =>
+      {
+        enable_audit_log_forwarding = (
+          lower(try(row.audit_log_forwarding_override, "")) == "y" ? true :
+          lower(try(row.audit_log_forwarding_override, "")) == "n" ? false :
+          var.enable_audit_log_forwarding
+        )
+      }
+  }
 
   # Parse the content from the external data source
   logging_services = jsondecode(data.external.logging_services.result["content"])
@@ -24,11 +33,11 @@ locals {
 
   # Generate a Cartesian product of compartments and filtered services
   logging_targets = flatten([
-    for compartment_id in local.logging_compartment_ids : [
+    for compartment_id in keys(local.logging_configurations) : [
       for service in local.filtered_services : {
-        compartment_id = compartment_id
-        service_id     = service.id
-        resource_types = service.resourceTypes
+      compartment_id = compartment_id
+      service_id     = service.id
+      resource_types = service.resourceTypes
       }
     ]
   ])

--- a/datadog-logs-oci-orm/locals.tf
+++ b/datadog-logs-oci-orm/locals.tf
@@ -104,8 +104,8 @@ locals {
   service_map = tomap({
     for key, values in local.service_category_map : 
     key => (
-      length([for value in values : value if startswith(value, "all")]) > 0 ? 
-      [for value in values : value if startswith(value, "all")] : 
+      length([for value in values : value if substr(value, 0, 3) == "all"]) > 0 ? 
+      [for value in values : value if substr(value, 0, 3) == "all"] : 
       values
     )
   })

--- a/datadog-logs-oci-orm/locals.tf
+++ b/datadog-logs-oci-orm/locals.tf
@@ -110,35 +110,3 @@ locals {
     )
   })
 }
-
-locals {
-    allowed_service_ids = [for key, value in local.service_map : split("_", key)[0]]
-    filtered_logs = flatten([
-        for log_group in data.oci_logging_logs.logs_by_log_group : [
-            for log in log_group.logs :
-            # Filter logs based on the allowed_services variable
-            {
-                log_group_ocid  = log.log_group_id
-                #log_ocid       = log.id
-                state           = log.state
-                #log_type       = log.log_type
-                compartment_id  = log.compartment_id
-                is_enabled      = log.is_enabled
-                resource_id     = try(log.configuration[0].source[0].resource, null)
-                service_id      = try(log.configuration[0].source[0].service, null)
-                category        = try(log.configuration[0].source[0].category, null)
-            } if contains(local.allowed_service_ids, try(log.configuration[0].source[0].service, ""))
-        ]
-    ])
-
-    # Map for resourceId_service_category => [{loggroupid, state, is_enabled}]
-    logs_map = tomap({
-        for log in local.filtered_logs : 
-        "${log.resource_id}_${log.service_id}_${log.category}" => {
-            loggroupid = log.log_group_ocid
-            state      = log.state
-            is_enabled = log.is_enabled
-            compartmentid = log.compartment_id
-        }
-    })
-}

--- a/datadog-logs-oci-orm/main.tf
+++ b/datadog-logs-oci-orm/main.tf
@@ -1,4 +1,3 @@
-/*
 module "vcn" {
     source = "./modules/vcn"
     compartment_ocid = var.vcn_compartment
@@ -48,7 +47,7 @@ module "function" {
     function_app_ocid = module.functionapp.function_app_details.function_app_ocid
     function_image_path = var.function_image_path == "" ? module.containerregistry[0].containerregistry_details.function_image_path : var.function_image_path
 }
-*/
+
 module "resourcediscovery" {
     for_each = { for target in local.logging_targets : "${target.compartment_id}_${target.service_id}" => target }
     source = "./modules/resourcediscovery"

--- a/datadog-logs-oci-orm/main.tf
+++ b/datadog-logs-oci-orm/main.tf
@@ -10,7 +10,6 @@ module "vcn" {
 module "policy" {
     source = "./modules/policy"
     tenancy_ocid = var.tenancy_ocid
-    resource_name_prefix = var.resource_name_prefix
     freeform_tags = local.freeform_tags
 }
 
@@ -19,7 +18,6 @@ module "functionapp" {
     compartment_ocid = var.compartment_ocid
     freeform_tags = local.freeform_tags
     resource_name_prefix = var.resource_name_prefix
-    function_app_shape = var.function_app_shape
     subnet_ocid = module.vcn.vcn_network_details.subnet_id
     datadog_api_key = var.datadog_api_key
     datadog_endpoint = var.datadog_endpoint
@@ -30,13 +28,11 @@ module "containerregistry" {
     source = "./modules/containerregistry"
     region = var.region
     tenancy_ocid = var.tenancy_ocid
-    user_ocid = var.service_user_ocid == "" ? var.current_user_ocid : var.service_user_ocid
-    auth_token_description = var.auth_token_description
-    auth_token = var.auth_token
+    username = var.oci_docker_username
+    auth_token = var.oci_docker_password
     resource_name_prefix = var.resource_name_prefix
     compartment_ocid = var.compartment_ocid
     freeform_tags = local.freeform_tags
-    count = var.function_image_path == "" ? 1 : 0
 }
 
 module "function" {
@@ -45,7 +41,7 @@ module "function" {
     freeform_tags = local.freeform_tags
     function_app_name = module.functionapp.function_app_details.function_app_name
     function_app_ocid = module.functionapp.function_app_details.function_app_ocid
-    function_image_path = var.function_image_path == "" ? module.containerregistry[0].containerregistry_details.function_image_path : var.function_image_path
+    function_image_path = module.containerregistry.containerregistry_details.function_image_path
 }
 
 module "resourcediscovery" {
@@ -57,11 +53,20 @@ module "resourcediscovery" {
 }
 
 module "logging" {
-    for_each = toset(keys(local.logging_configurations))
+    for_each = local.logging_compartment_ids
     source = "./modules/logging"
     tenancy_ocid = var.tenancy_ocid
     compartment_ocid = each.value
     service_map = local.service_map
     resources = flatten(lookup(local.compartment_resources,each.value,[]))
-    enable_audit_log_forwarding = local.logging_configurations[each.value].enable_audit_log_forwarding
+}
+
+module "connectorhub" {
+    source = "./modules/connectorhub"
+    freeform_tags = local.freeform_tags
+    compartment_ocid = var.compartment_ocid
+    resource_name_prefix = var.resource_name_prefix
+    function_ocid = module.function.function_details.function_ocid
+    service_log_groups = local.service_log_groups
+    audit_log_compartments = var.enable_audit_log_forwarding ? local.logging_compartment_ids : []
 }

--- a/datadog-logs-oci-orm/main.tf
+++ b/datadog-logs-oci-orm/main.tf
@@ -57,10 +57,11 @@ module "resourcediscovery" {
 }
 
 module "logging" {
-    for_each = toset(local.logging_compartment_ids)
+    for_each = toset(keys(local.logging_configurations))
     source = "./modules/logging"
     tenancy_ocid = var.tenancy_ocid
     compartment_ocid = each.value
     service_map = local.service_map
     resources = flatten(lookup(local.compartment_resources,each.value,[]))
+    enable_audit_log_forwarding = local.logging_configurations[each.value].enable_audit_log_forwarding
 }

--- a/datadog-logs-oci-orm/main.tf
+++ b/datadog-logs-oci-orm/main.tf
@@ -59,8 +59,8 @@ module "resourcediscovery" {
 module "logging" {
     for_each = toset(local.logging_compartment_ids)
     source = "./modules/logging"
+    tenancy_ocid = var.tenancy_ocid
     compartment_ocid = each.value
     service_map = local.service_map
     resources = flatten(lookup(local.compartment_resources,each.value,[]))
-    logs_map = local.logs_map
 }

--- a/datadog-logs-oci-orm/main.tf
+++ b/datadog-logs-oci-orm/main.tf
@@ -1,3 +1,4 @@
+/*
 module "vcn" {
     source = "./modules/vcn"
     compartment_ocid = var.vcn_compartment
@@ -47,7 +48,7 @@ module "function" {
     function_app_ocid = module.functionapp.function_app_details.function_app_ocid
     function_image_path = var.function_image_path == "" ? module.containerregistry[0].containerregistry_details.function_image_path : var.function_image_path
 }
-
+*/
 module "resourcediscovery" {
     for_each = { for target in local.logging_targets : "${target.compartment_id}_${target.service_id}" => target }
     source = "./modules/resourcediscovery"
@@ -60,6 +61,7 @@ module "logging" {
     for_each = toset(local.logging_compartment_ids)
     source = "./modules/logging"
     compartment_ocid = each.value
-    service_map = local.service_category_map
+    service_map = local.service_map
     resources = flatten(lookup(local.compartment_resources,each.value,[]))
+    logs_map = local.logs_map
 }

--- a/datadog-logs-oci-orm/main.tf
+++ b/datadog-logs-oci-orm/main.tf
@@ -55,3 +55,11 @@ module "resourcediscovery" {
     group_id = each.value.service_id
     resource_types = [for rt in each.value.resource_types : rt.name]
 }
+
+module "logging" {
+    for_each = toset(local.logging_compartment_ids)
+    source = "./modules/logging"
+    compartment_ocid = each.value
+    service_map = local.service_category_map
+    resources = flatten(lookup(local.compartment_resources,each.value,[]))
+}

--- a/datadog-logs-oci-orm/modules/connectorhub/locals.tf
+++ b/datadog-logs-oci-orm/modules/connectorhub/locals.tf
@@ -1,0 +1,5 @@
+locals {
+  # Names for the service connector
+  service_connector_name = "${var.resource_name_prefix}-service-logs-connector"
+  audit_connector_name = "${var.resource_name_prefix}-audit-logs-connector"
+}

--- a/datadog-logs-oci-orm/modules/connectorhub/main.tf
+++ b/datadog-logs-oci-orm/modules/connectorhub/main.tf
@@ -1,0 +1,54 @@
+# Service Log Connector
+resource "oci_sch_service_connector" "service_log_connector" {
+    compartment_id = var.compartment_ocid
+    display_name   = local.service_connector_name
+    description    = "Terraform created connector hub to distribute service logs"
+
+    source {
+        kind = "logging"
+        dynamic "log_sources" {
+            for_each = var.service_log_groups
+            content {
+                compartment_id = log_sources.value.compartment_id
+                log_group_id   = log_sources.value.log_group_id
+            }
+        }
+    }
+
+    target {
+        kind              = "functions"
+        batch_size_in_kbs = 5000
+        batch_time_in_sec = 60
+        function_id       = var.function_ocid
+    }
+
+    freeform_tags = var.freeform_tags
+}
+
+# Audit Log Connector
+resource "oci_sch_service_connector" "audit_log_connector" {
+    count          = length(var.audit_log_compartments) > 0 ? 1 : 0
+    compartment_id = var.compartment_ocid
+    display_name   = local.audit_connector_name
+    description    = "Terraform created connector hub to distribute audit logs"
+
+    source {
+        kind = "logging"
+        dynamic "log_sources" {
+            for_each = var.audit_log_compartments
+            content {
+                compartment_id = log_sources.value
+                log_group_id   = "_Audit"
+            }
+        }
+    }
+
+    target {
+        kind              = "functions"
+        batch_size_in_kbs = 5000
+        batch_time_in_sec = 60
+        function_id       = var.function_ocid
+    }
+
+    freeform_tags = var.freeform_tags
+}

--- a/datadog-logs-oci-orm/modules/connectorhub/output.tf
+++ b/datadog-logs-oci-orm/modules/connectorhub/output.tf
@@ -1,0 +1,9 @@
+output "connectorhub_details" {
+  description = "Output of connector hub"
+  value       = {
+    service_connector_name = oci_sch_service_connector.service_log_connector.display_name
+    service_connector_ocid = oci_sch_service_connector.service_log_connector.id
+    audit_connector_name   = length(oci_sch_service_connector.audit_log_connector) > 0 ? oci_sch_service_connector.audit_log_connector[0].display_name : ""
+    audit_connector_ocid   = length(oci_sch_service_connector.audit_log_connector) > 0 ? oci_sch_service_connector.audit_log_connector[0].id : ""
+  }
+}

--- a/datadog-logs-oci-orm/modules/connectorhub/variables.tf
+++ b/datadog-logs-oci-orm/modules/connectorhub/variables.tf
@@ -1,0 +1,33 @@
+variable "compartment_ocid" {
+  type        = string
+  description = "The OCID of the compartment where resources exist"
+}
+
+variable "freeform_tags" {
+  type        = map(string)
+  description = "A map of freeform tags to apply to the resources"
+  default     = {}
+}
+
+variable "resource_name_prefix" {
+  type        = string
+  description = "The prefix for the name of all of the resources"
+}
+
+variable "function_ocid" {
+  description = "OCID of the function to which logs will be sent"
+  type        = string
+}
+
+variable "audit_log_compartments" {
+  description = "List of audit log compartments"
+  type        = list(string)
+}
+
+variable "service_log_groups" {
+  description = "A list of maps where each map contains details about an audit log group, including the log group ID and the compartment ID where it is located."
+  type = list(object({
+    log_group_id   = string
+    compartment_id = string
+  }))
+}

--- a/datadog-logs-oci-orm/modules/containerregistry/data.tf
+++ b/datadog-logs-oci-orm/modules/containerregistry/data.tf
@@ -1,8 +1,3 @@
 data "oci_objectstorage_namespace" "namespace" {
   compartment_id = var.tenancy_ocid
 }
-
-data "oci_identity_user" "docker_user" {
-    #Required
-    user_id = var.user_ocid
-}

--- a/datadog-logs-oci-orm/modules/containerregistry/locals.tf
+++ b/datadog-logs-oci-orm/modules/containerregistry/locals.tf
@@ -5,5 +5,4 @@ locals {
   function_name = "datadog-function-logs"
   repo_name = "${var.resource_name_prefix}-functions/${local.function_name}"
   docker_image_path = "${local.registry_domain}/${local.tenancy_namespace}/${local.repo_name}"
-  username = data.oci_identity_user.docker_user.name
 }

--- a/datadog-logs-oci-orm/modules/containerregistry/login.tf
+++ b/datadog-logs-oci-orm/modules/containerregistry/login.tf
@@ -1,61 +1,11 @@
-resource "null_resource" "recreate_auth_token" {
-    count = "${var.auth_token != "" ? 0 : 1}"
-    provisioner "local-exec" {
-        command = <<EOT
-            #!/bin/bash
-            set -e
-
-            # Step 1: List existing auth tokens
-            echo "Listing existing auth tokens..."
-            existing_token_ocid=$(oci iam auth-token list --user-id ${var.user_ocid} \
-                --query "data[?description=='${var.auth_token_description}'].id | [0]" --raw-output)
-
-            if [ "$existing_token_ocid" != "" ]; then
-                echo "Deleting existing auth token: $existing_token_ocid"
-                oci iam auth-token delete --user-id ${var.user_ocid} --auth-token-id $existing_token_ocid --force
-            else
-                # Check the total number of existing tokens
-                total_tokens=$(oci iam auth-token list --user-id ${var.user_ocid} --query "length(data)" --raw-output)
-                
-                if [ "$total_tokens" -eq 2 ]; then
-                    echo "Error: Total existing tokens are equal to 2. Cannot create a new token."
-                    exit 1
-                fi
-                echo "No existing auth token with description '${var.auth_token_description}' found. Proceeding to create a new one."
-            fi
-
-            # Step 2: Create a new auth token
-            echo "Creating a new auth token..."
-            new_token_value=$(oci iam auth-token create --user-id ${var.user_ocid} \
-                --description "${var.auth_token_description}" --query "data.token" --raw-output)
-
-            # Step 3: Sleep for 30 seconds to ensure token propagation
-            echo "Waiting for 60 seconds to ensure token availability..."
-            sleep 60
-
-            echo $new_token_value > /tmp/new_auth_token.txt
-        EOT
-    }
-    triggers = {
-        always_run = "${timestamp()}"
-    }
-}
-
 resource "null_resource" "Login2OCIR" {
-    depends_on = [null_resource.recreate_auth_token]
     provisioner "local-exec" {
         command = <<EOT
             #!/bin/bash
             set -e
 
-            # Run the current command
-            if [ "${var.auth_token}" != "" ]; then
-                auth_token="${var.auth_token}"
-            else
-                auth_token=$(cat /tmp/new_auth_token.txt && rm -f /tmp/new_auth_token.txt)
-            fi
             for i in {1..5}; do
-                echo "$auth_token" | docker login ${local.registry_domain} --username ${local.tenancy_namespace}/${local.username} --password-stdin && break
+                echo "${var.auth_token}" | docker login ${local.registry_domain} --username ${local.tenancy_namespace}/${var.username} --password-stdin && break
                 echo "Retrying Docker login... attempt $i"
                 sleep 10
             done
@@ -64,7 +14,7 @@ resource "null_resource" "Login2OCIR" {
             if [ $i -eq 5 ]; then
                 echo "Error: Docker login failed after 5 attempts. Trying to login through Oracle Identity Cloud Service"
                 for j in {1..5}; do
-                    echo "$auth_token" | docker login ${local.registry_domain} --username ${local.tenancy_namespace}/oracleidentitycloudservice/$username --password-stdin && break
+                    echo "${var.auth_token}" | docker login ${local.registry_domain} --username ${local.tenancy_namespace}/oracleidentitycloudservice/${var.username} --password-stdin && break
                     echo "Retrying Docker login through Identity service... attempt $j"
                     sleep 5
                 done

--- a/datadog-logs-oci-orm/modules/containerregistry/variables.tf
+++ b/datadog-logs-oci-orm/modules/containerregistry/variables.tf
@@ -3,9 +3,9 @@ variable "tenancy_ocid" {
   description = "OCI tenant OCID, more details can be found at https://docs.cloud.oracle.com/en-us/iaas/Content/API/Concepts/apisigningkey.htm#five"
 }
 
-variable "user_ocid" {
+variable "username" {
   type        = string
-  description = "OCID of the user for managing docker images"
+  description = "Username for managing docker images"
 }
 
 variable "compartment_ocid" {
@@ -27,11 +27,6 @@ variable "resource_name_prefix" {
 variable "region" {
   type        = string
   description = "OCI Region as documented at https://docs.cloud.oracle.com/en-us/iaas/Content/General/Concepts/regions.htm"
-}
-
-variable "auth_token_description" {
-  description = "The description of the auth token to use for container registry login"
-  type        = string
 }
 
 variable "auth_token" {

--- a/datadog-logs-oci-orm/modules/functionapp/main.tf
+++ b/datadog-logs-oci-orm/modules/functionapp/main.tf
@@ -11,7 +11,7 @@ resource "oci_functions_application" "logs_function_app" {
   freeform_tags = var.freeform_tags
   network_security_group_ids = [
   ]
-  shape = var.function_app_shape
+  shape = "GENERIC_ARM"
   subnet_ids = [
     var.subnet_ocid,
   ]

--- a/datadog-logs-oci-orm/modules/functionapp/variables.tf
+++ b/datadog-logs-oci-orm/modules/functionapp/variables.tf
@@ -17,16 +17,6 @@ variable "resource_name_prefix" {
 #************************************
 #   Function Application Variables   
 #************************************
-variable "function_app_shape" {
-  type        = string
-  default     = "GENERIC_ARM"
-  description = "The shape of the function application. The docker image should be built accordingly. Use ARM if using Oracle Resource managaer stack"
-  validation {
-    condition     = contains(["GENERIC_ARM", "GENERIC_X86", "GENERIC_X86_ARM"], var.function_app_shape)
-    error_message = "Valid values are: GENERIC_ARM, GENERIC_X86, GENERIC_X86_ARM."
-  }
-}
-
 variable "subnet_ocid" {
   type        = string
   description = "The OCID of the subnet to be used for the function app"

--- a/datadog-logs-oci-orm/modules/logging/data.tf
+++ b/datadog-logs-oci-orm/modules/logging/data.tf
@@ -6,6 +6,17 @@ data "oci_logging_log_groups" "datadog_log_group" {
     display_name = "datadog-service-logs"
 }
 
+
+data "oci_logging_log_groups" "audit_log_group" {
+    count = var.enable_audit_log_forwarding ? 1 : 0
+
+    #Required
+    compartment_id = var.compartment_ocid
+
+    #Optional
+    display_name = "_Audit"
+}
+
 # Step 1: Fetch all compartments in the tenancy
 data "oci_identity_compartments" "all_compartments" {
   compartment_id = var.tenancy_ocid

--- a/datadog-logs-oci-orm/modules/logging/data.tf
+++ b/datadog-logs-oci-orm/modules/logging/data.tf
@@ -6,17 +6,6 @@ data "oci_logging_log_groups" "datadog_log_group" {
     display_name = "datadog-service-logs"
 }
 
-
-data "oci_logging_log_groups" "audit_log_group" {
-    count = var.enable_audit_log_forwarding ? 1 : 0
-
-    #Required
-    compartment_id = var.compartment_ocid
-
-    #Optional
-    display_name = "_Audit"
-}
-
 # Step 1: Fetch all compartments in the tenancy
 data "oci_identity_compartments" "all_compartments" {
   compartment_id = var.tenancy_ocid

--- a/datadog-logs-oci-orm/modules/logging/data.tf
+++ b/datadog-logs-oci-orm/modules/logging/data.tf
@@ -1,4 +1,4 @@
-data "oci_logging_log_groups" "datadog_log_group" {
+data "oci_logging_log_groups" "datadog_service_log_group" {
     #Required
     compartment_id = var.compartment_ocid
 

--- a/datadog-logs-oci-orm/modules/logging/data.tf
+++ b/datadog-logs-oci-orm/modules/logging/data.tf
@@ -1,4 +1,4 @@
-data "oci_logging_log_groups" "test_log_groups" {
+data "oci_logging_log_groups" "datadog_log_group" {
     #Required
     compartment_id = var.compartment_ocid
 

--- a/datadog-logs-oci-orm/modules/logging/data.tf
+++ b/datadog-logs-oci-orm/modules/logging/data.tf
@@ -1,0 +1,10 @@
+data "oci_logging_log_groups" "log_groups" {
+    #Required
+    compartment_id = var.compartment_ocid
+}
+
+data "oci_logging_logs" "existing_logs" {
+    #Required
+    for_each = { for log_group in data.oci_logging_log_groups.log_groups.log_groups : log_group.id => log_group }
+    log_group_id = each.value.id
+}

--- a/datadog-logs-oci-orm/modules/logging/data.tf
+++ b/datadog-logs-oci-orm/modules/logging/data.tf
@@ -41,7 +41,7 @@ data "external" "logs_outside_compartment" {
       "bash",
       "modules/logging/search_logs_outside_compartment.sh",
       local.log_group_ids_string,
-      each.key,
+      each.value.resource_id,
       each.value.log_group != null ? "Y" : "N"
     ]
 }

--- a/datadog-logs-oci-orm/modules/logging/data.tf
+++ b/datadog-logs-oci-orm/modules/logging/data.tf
@@ -1,10 +1,7 @@
-data "oci_logging_log_groups" "log_groups" {
+data "oci_logging_log_groups" "test_log_groups" {
     #Required
     compartment_id = var.compartment_ocid
-}
 
-data "oci_logging_logs" "existing_logs" {
-    #Required
-    for_each = { for log_group in data.oci_logging_log_groups.log_groups.log_groups : log_group.id => log_group }
-    log_group_id = each.value.id
+    #Optional
+    display_name = "datadog-service-logs"
 }

--- a/datadog-logs-oci-orm/modules/logging/data.tf
+++ b/datadog-logs-oci-orm/modules/logging/data.tf
@@ -5,3 +5,43 @@ data "oci_logging_log_groups" "datadog_log_group" {
     #Optional
     display_name = "datadog-service-logs"
 }
+
+# Step 1: Fetch all compartments in the tenancy
+data "oci_identity_compartments" "all_compartments" {
+  compartment_id = var.tenancy_ocid
+  state = "ACTIVE"
+  compartment_id_in_subtree = true
+}
+
+# Step 2: Fetch all log groups in each compartment
+data "oci_logging_log_groups" "log_groups_by_compartment" {
+  for_each       = toset([for compartment in data.oci_identity_compartments.all_compartments.compartments : compartment.id])
+  compartment_id = each.value
+}
+
+# Step 3: Fetch all logs from this compartment
+data "oci_logging_logs" "existing_logs" {
+    #Required
+    for_each = { for log_group in data.oci_logging_log_groups.log_groups_by_compartment[var.compartment_ocid].log_groups : log_group.id => log_group }
+    log_group_id = each.value.id
+}
+
+# Step 4: Fetch all logs in other compartments for resources without them
+locals {
+  flat_log_groups = flatten([
+    for compartment_id, log_group_data in data.oci_logging_log_groups.log_groups_by_compartment : log_group_data.log_groups
+    if compartment_id != var.compartment_ocid
+  ])
+  log_group_ids_string = join(",", [for lg in local.flat_log_groups : lg.id])
+}
+
+data "external" "logs_outside_compartment" {
+    for_each = { for resource in local.resource_evaluation : "${resource.resource_id}-${resource.category}" => resource }
+    program = [
+      "bash",
+      "modules/logging/search_logs_outside_compartment.sh",
+      local.log_group_ids_string,
+      each.key,
+      each.value.log_group != null ? "Y" : "N"
+    ]
+}

--- a/datadog-logs-oci-orm/modules/logging/locals.tf
+++ b/datadog-logs-oci-orm/modules/logging/locals.tf
@@ -1,41 +1,97 @@
 locals {
-    resource_evaluation = flatten([
+    # List of allowed service IDs extracted from the service map keys
+    allowed_service_ids = [for key, value in var.service_map : split("_", key)[0]]
+    
+    # Flattened list of logs filtered based on allowed service IDs
+    filtered_logs = flatten([
+        for log_group in data.oci_logging_logs.existing_logs : [
+            for log in log_group.logs :
+            # Filter logs based on the allowed_services variable
+            {
+                log_group_id   = log.log_group_id
+                state          = log.state
+                compartment_id = log.compartment_id
+                is_enabled     = log.is_enabled
+                resource_id    = try(log.configuration[0].source[0].resource, null)
+                service_id     = try(log.configuration[0].source[0].service, null)
+                category       = try(log.configuration[0].source[0].category, null)
+            } if contains(local.allowed_service_ids, try(log.configuration[0].source[0].service, ""))
+        ]
+    ])
+    
+    # Map for resource_id_service_category => [{log_group_id, state, is_enabled}]
+    logs_map = tomap({
+        for log in local.filtered_logs : 
+        "${log.resource_id}_${log.service_id}_${log.category}" => {
+            log_group_id   = log.log_group_id
+            state          = log.state
+            is_enabled     = log.is_enabled
+            compartment_id = log.compartment_id
+        }
+    })
+}
+
+locals {
+    # Flattened list of resource evaluations based on the service map
+    resource_evaluation = toset(flatten([
         for resource in var.resources : [
             for category in lookup(var.service_map, "${resource.groupId}_${resource.resourceType}", []) : {
                 service_id    = resource.groupId
                 resource_id   = resource.identifier
                 resource_name = resource.displayName
                 category      = category
-                time_created   = lookup(resource, "timeCreated", "")
-                loggroup      = lookup(var.logs_map, "${resource.identifier}_${resource.groupId}_${category}", null)
+                time_created  = lookup(resource, "timeCreated", "")
+                log_group     = lookup(local.logs_map, "${resource.identifier}_${resource.groupId}_${category}", null)
             }
         ]
-    ])
+    ]))
     
-    sorted_keys = sort([for item in local.resource_evaluation : "${item.time_created}_${item.resource_id}_${item.service_id}_${item.category}"])
+    # Updated resource evaluation with logs outside the compartment
+    updated_resource_evaluation = [
+        for resource in local.resource_evaluation : {
+            service_id    = resource.service_id
+            resource_id   = resource.resource_id
+            resource_name = resource.resource_name
+            category      = resource.category
+            time_created  = resource.time_created
+            log_group     = (data.external.logs_outside_compartment["${resource.resource_id}-${resource.category}"].result.content != "" ? 
+                            jsondecode(data.external.logs_outside_compartment["${resource.resource_id}-${resource.category}"].result.content) : resource.log_group)
+        }
+    ]
+
+    # Sorted keys for resource evaluation based on time created, resource ID, service ID, and category
+    sorted_keys = sort([for item in local.updated_resource_evaluation : "${item.time_created}_${item.resource_id}_${item.service_id}_${item.category}"])
+    
+    # Sorted resource evaluation based on sorted keys
     sorted_resource_evaluation = [
         for key in local.sorted_keys : lookup(
-            { for item in local.resource_evaluation : "${item.time_created}_${item.resource_id}_${item.service_id}_${item.category}" => item },
+            { for item in local.updated_resource_evaluation : "${item.time_created}_${item.resource_id}_${item.service_id}_${item.category}" => item },
             key
         )
     ]
+    
 }
 
 locals {
+    # Datadog log group ID
     datadog_log_group_id = try(data.oci_logging_log_groups.datadog_log_group.log_groups[0].id, null)
-    loggroups = toset([
+    
+    # Set of log groups excluding the Datadog log group
+    log_groups = toset([
         for item in local.sorted_resource_evaluation : {
-            loggroupid    = item.loggroup.loggroupid
-            compartmentid = item.loggroup.compartmentid
+            log_group_id   = item.log_group.log_group_id
+            compartment_id = item.log_group.compartment_id
         }
-        if item.loggroup != null && try(item.loggroup.loggroupid, "") != local.datadog_log_group_id
+        if item.log_group != null && try(item.log_group.log_group_id, "") != local.datadog_log_group_id
     ])
 
+    # Map of resources without logs or with logs in the Datadog log group
     resources_without_logs = zipmap(
         [for idx, item in range(length(local.sorted_resource_evaluation)) :
             "${local.sorted_resource_evaluation[idx].resource_name}_${local.sorted_resource_evaluation[idx].category}_${idx}"
-            if local.sorted_resource_evaluation[idx].loggroup == null || try(local.sorted_resource_evaluation[idx].loggroup.loggroupid, "") == local.datadog_log_group_id
+            if local.sorted_resource_evaluation[idx].log_group == null || try(local.sorted_resource_evaluation[idx].log_group.log_group_id, "") == local.datadog_log_group_id
         ],
-        [for item in local.sorted_resource_evaluation : item if item.loggroup == null || try(item.loggroup.loggroupid, "") == local.datadog_log_group_id]
+        [for item in local.sorted_resource_evaluation : item if item.log_group == null || try(item.log_group.log_group_id, "") == local.datadog_log_group_id]
     )
+    
 }

--- a/datadog-logs-oci-orm/modules/logging/locals.tf
+++ b/datadog-logs-oci-orm/modules/logging/locals.tf
@@ -62,7 +62,7 @@ locals {
 
 locals {
     # Datadog log group ID
-    datadog_log_group_id = try(data.oci_logging_log_groups.datadog_log_group.log_groups[0].id, null)
+    datadog_service_log_group_id = try(data.oci_logging_log_groups.datadog_service_log_group.log_groups[0].id, null)
     
     # Set of log groups excluding the Datadog log group
     log_groups = toset([
@@ -70,16 +70,16 @@ locals {
             log_group_id   = item.log_group.log_group_id
             compartment_id = item.log_group.compartment_id
         }
-        if item.log_group != null && try(item.log_group.log_group_id, "") != local.datadog_log_group_id
+        if item.log_group != null && try(item.log_group.log_group_id, "") != local.datadog_service_log_group_id
     ])
 
     # Map of resources without logs or with logs in the Datadog log group
     resources_without_logs = zipmap(
         [for idx, item in range(length(local.updated_resource_evaluation)) :
             "${local.updated_resource_evaluation[idx].resource_id}_${local.updated_resource_evaluation[idx].category}"
-            if local.updated_resource_evaluation[idx].log_group == null || try(local.updated_resource_evaluation[idx].log_group.log_group_id, "") == local.datadog_log_group_id
+            if local.updated_resource_evaluation[idx].log_group == null || try(local.updated_resource_evaluation[idx].log_group.log_group_id, "") == local.datadog_service_log_group_id
         ],
-        [for item in local.updated_resource_evaluation : item if item.log_group == null || try(item.log_group.log_group_id, "") == local.datadog_log_group_id]
+        [for item in local.updated_resource_evaluation : item if item.log_group == null || try(item.log_group.log_group_id, "") == local.datadog_service_log_group_id]
     )
     
 }

--- a/datadog-logs-oci-orm/modules/logging/locals.tf
+++ b/datadog-logs-oci-orm/modules/logging/locals.tf
@@ -1,0 +1,59 @@
+locals {
+    allowed_service_ids = [for key, value in var.service_map : split("_", key)[0]]
+    filtered_logs = flatten([
+        for log_group in data.oci_logging_logs.existing_logs : [
+            for log in log_group.logs :
+            # Filter logs based on the allowed_services variable
+            {
+                log_group_ocid = log.log_group_id
+                #log_ocid       = log.id
+                state          = log.state
+                #log_type       = log.log_type
+                compartment_id = log.compartment_id
+                is_enabled     = log.is_enabled
+                resource_id    = try(log.configuration[0].source[0].resource, null)
+                service_id     = try(log.configuration[0].source[0].service, null)
+                category       = try(log.configuration[0].source[0].category, null)
+            } if contains(local.allowed_service_ids, try(log.configuration[0].source[0].service, ""))
+        ]
+    ])
+
+    # Map for resourceId_service_category => [{loggroupid, state, is_enabled}]
+    logs_map = tomap({
+        for log in local.filtered_logs : 
+        "${log.resource_id}_${log.service_id}_${log.category}" => {
+            loggroupid = log.log_group_ocid
+            state      = log.state
+            is_enabled = log.is_enabled
+        }
+    })
+}
+
+locals {
+    resource_evaluation = flatten([
+        for resource in var.resources : [
+            for category in lookup(var.service_map, "${resource.groupId}_${resource.resourceType}", []) : {
+                service_id    = resource.groupId
+                resource_id   = resource.identifier
+                resource_name = resource.displayName
+                category      = category
+                loggroup      = lookup(local.logs_map, "${resource.identifier}_${resource.groupId}_${category}", null)
+            }
+        ]
+    ])
+
+    resources_without_logs = [
+        for item in local.resource_evaluation : {
+            service_id    = item.service_id
+            resource_id   = item.resource_id
+            resource_name = item.resource_name
+            category      = item.category
+        }
+        if item.loggroup == null
+    ]
+
+    loggroup_ids = toset([
+        for item in local.resource_evaluation : item.loggroup.loggroupid
+        if item.loggroup != null
+    ])
+}

--- a/datadog-logs-oci-orm/modules/logging/locals.tf
+++ b/datadog-logs-oci-orm/modules/logging/locals.tf
@@ -22,7 +22,7 @@ locals {
 }
 
 locals {
-    datadog_log_group_id = try(data.oci_logging_log_groups.test_log_groups.log_groups[0].id, null)
+    datadog_log_group_id = try(data.oci_logging_log_groups.datadog_log_group.log_groups[0].id, null)
     loggroups = toset([
         for item in local.sorted_resource_evaluation : {
             loggroupid    = item.loggroup.loggroupid

--- a/datadog-logs-oci-orm/modules/logging/main.tf
+++ b/datadog-logs-oci-orm/modules/logging/main.tf
@@ -1,0 +1,35 @@
+resource "oci_logging_log_group" "datadog_service_log_group" {
+    count = length(local.resources_without_logs) > 0 ? 1 : 0
+    #Required
+    compartment_id = var.compartment_ocid
+    display_name = "datadog-service-logs"
+
+    #Optional
+    description = "[DO NOT REMOVE] This log group is managed by the system. Do not edit. It is used for forwarding logs to Datadog."
+    freeform_tags = var.freeform_tags
+}
+
+resource "oci_logging_log" "service_logs" {
+    for_each = local.resources_without_logs
+    #Required
+    display_name = replace(each.key, " ", "_")
+    log_group_id = oci_logging_log_group.datadog_service_log_group[0].id
+    log_type = "SERVICE"
+
+    #Optional
+    configuration {
+        #Required
+        source {
+            #Required
+            category = each.value.category
+            resource = each.value.service_id == "objectstorage" ? each.value.resource_name : each.value.resource_id
+            service = each.value.service_id
+            source_type = "OCISERVICE"
+
+        }
+
+        #Optional
+        compartment_id = var.compartment_ocid
+    }
+    freeform_tags = var.freeform_tags
+}

--- a/datadog-logs-oci-orm/modules/logging/main.tf
+++ b/datadog-logs-oci-orm/modules/logging/main.tf
@@ -12,7 +12,7 @@ resource "oci_logging_log_group" "datadog_service_log_group" {
 resource "oci_logging_log" "service_logs" {
     for_each = local.resources_without_logs
     #Required
-    display_name = replace(each.key, " ", "_")
+    display_name = each.key
     log_group_id = oci_logging_log_group.datadog_service_log_group[0].id
     log_type = "SERVICE"
 

--- a/datadog-logs-oci-orm/modules/logging/output.tf
+++ b/datadog-logs-oci-orm/modules/logging/output.tf
@@ -3,6 +3,5 @@ output "details" {
   value       = {
     preexisting_loggroups = local.log_groups
     datadog_service_loggroup_id = length(oci_logging_log_group.datadog_service_log_group) > 0 ? oci_logging_log_group.datadog_service_log_group[0].id : null
-    loggroups = { for k, v in data.external.logs_outside_compartment : k => v.result.content if v.result.content != "" }
   }
 }

--- a/datadog-logs-oci-orm/modules/logging/output.tf
+++ b/datadog-logs-oci-orm/modules/logging/output.tf
@@ -3,5 +3,6 @@ output "details" {
   value       = {
     preexisting_loggroups = local.log_groups
     datadog_service_loggroup_id = length(oci_logging_log_group.datadog_service_log_group) > 0 ? oci_logging_log_group.datadog_service_log_group[0].id : null
+    audit_log_group_id = length(data.oci_logging_log_groups.audit_log_group) > 0 ? data.oci_logging_log_groups.audit_log_group[0].id : null
   }
 }

--- a/datadog-logs-oci-orm/modules/logging/output.tf
+++ b/datadog-logs-oci-orm/modules/logging/output.tf
@@ -1,7 +1,8 @@
 output "details" {
   description = "Output of logging"
   value       = {
-    preexisting_loggroups = local.loggroups
+    preexisting_loggroups = local.log_groups
     datadog_service_loggroup_id = length(oci_logging_log_group.datadog_service_log_group) > 0 ? oci_logging_log_group.datadog_service_log_group[0].id : null
+    loggroups = { for k, v in data.external.logs_outside_compartment : k => v.result.content if v.result.content != "" }
   }
 }

--- a/datadog-logs-oci-orm/modules/logging/output.tf
+++ b/datadog-logs-oci-orm/modules/logging/output.tf
@@ -1,5 +1,5 @@
 output "details" {
-  description = "Output of logging"
+  description = "Output of logging module execution"
   value       = {
     preexisting_log_groups = local.log_groups
     datadog_service_log_group_id = length(oci_logging_log_group.datadog_service_log_group) > 0 ? oci_logging_log_group.datadog_service_log_group[0].id : null

--- a/datadog-logs-oci-orm/modules/logging/output.tf
+++ b/datadog-logs-oci-orm/modules/logging/output.tf
@@ -1,8 +1,7 @@
 output "details" {
   description = "Output of logging"
   value       = {
-    logs = local.logs_map
-    resources_without_logs = local.resources_without_logs
-    log_groups = local.loggroup_ids
-    }
+    preexisting_loggroups = local.loggroups
+    datadog_service_loggroup_id = length(oci_logging_log_group.datadog_service_log_group) > 0 ? oci_logging_log_group.datadog_service_log_group[0].id : null
+  }
 }

--- a/datadog-logs-oci-orm/modules/logging/output.tf
+++ b/datadog-logs-oci-orm/modules/logging/output.tf
@@ -1,0 +1,8 @@
+output "details" {
+  description = "Output of logging"
+  value       = {
+    logs = local.logs_map
+    resources_without_logs = local.resources_without_logs
+    log_groups = local.loggroup_ids
+    }
+}

--- a/datadog-logs-oci-orm/modules/logging/output.tf
+++ b/datadog-logs-oci-orm/modules/logging/output.tf
@@ -1,8 +1,7 @@
 output "details" {
   description = "Output of logging"
   value       = {
-    preexisting_loggroups = local.log_groups
-    datadog_service_loggroup_id = length(oci_logging_log_group.datadog_service_log_group) > 0 ? oci_logging_log_group.datadog_service_log_group[0].id : null
-    audit_log_group_id = length(data.oci_logging_log_groups.audit_log_group) > 0 ? data.oci_logging_log_groups.audit_log_group[0].id : null
+    preexisting_log_groups = local.log_groups
+    datadog_service_log_group_id = length(oci_logging_log_group.datadog_service_log_group) > 0 ? oci_logging_log_group.datadog_service_log_group[0].id : null
   }
 }

--- a/datadog-logs-oci-orm/modules/logging/search_logs_outside_compartment.sh
+++ b/datadog-logs-oci-orm/modules/logging/search_logs_outside_compartment.sh
@@ -18,7 +18,7 @@ for lgid in "${types[@]}"; do
     if [[ $(echo "$response" | jq 'length') -ne 0 ]]; then
         output_file="${RESOURCE_ID}.json"
         echo "[]" > $output_file # Initialize the output file with an empty JSON array
-        loggroup=$(echo "$response" | jq -c '.[0] | {log_group_id: .id, state: .["lifecycle-state"], is_enabled: .["is-enabled"], compartment_id: .["compartment-id"]}')
+        loggroup=$(echo "$response" | jq -c '.[0] | {log_group_id: .["log-group-id"], state: .["lifecycle-state"], is_enabled: .["is-enabled"], compartment_id: .["compartment-id"]}')
         # Write the response to the output file
         echo "$loggroup" > "$output_file"
         found=true

--- a/datadog-logs-oci-orm/modules/logging/search_logs_outside_compartment.sh
+++ b/datadog-logs-oci-orm/modules/logging/search_logs_outside_compartment.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+export LOG_GROUP_IDS="${1}"
+export RESOURCE_ID="${2}"
+export HAS_LOGGROUP="${3}"
+if [ "$HAS_LOGGROUP" = "Y" ]; then
+    echo "{\"content\": \"\"}"
+    exit 0
+fi
+
+IFS=',' read -ra types <<< "$LOG_GROUP_IDS"
+found=false
+for lgid in "${types[@]}"; do
+    response=$(oci logging log list --log-group-id $lgid \
+        --query "data[?configuration.source.resource=='${RESOURCE_ID}']" \
+        --output json)
+
+    if [[ $(echo "$response" | jq 'length') -ne 0 ]]; then
+        output_file="${RESOURCE_ID}.json"
+        echo "[]" > $output_file # Initialize the output file with an empty JSON array
+        loggroup=$(echo "$response" | jq -c '.[0] | {log_group_id: .id, state: .["lifecycle-state"], is_enabled: .["is-enabled"], compartment_id: .["compartment-id"]}')
+        # Write the response to the output file
+        echo "$loggroup" > "$output_file"
+        found=true
+        break
+    fi
+done
+if [ "$found" = false ]; then
+    echo "{\"content\": \"\"}"
+else
+    # Output the response in a valid JSON map for Terraform's external data source
+    content=$(jq -c . < "$output_file") # Ensure the file's content is compact JSON
+    rm -f "$output_file"
+    echo "{\"content\": \"$(echo "$content" | sed 's/"/\\"/g')\"}" # Escape quotes for JSON compatibility
+fi

--- a/datadog-logs-oci-orm/modules/logging/variables.tf
+++ b/datadog-logs-oci-orm/modules/logging/variables.tf
@@ -30,3 +30,8 @@ variable "resources" {
     timeCreated   = string
   }))
 }
+
+variable "enable_audit_log_forwarding" {
+  type        = bool
+  description = "Enable forwarding of audit logs to Datadog"
+}

--- a/datadog-logs-oci-orm/modules/logging/variables.tf
+++ b/datadog-logs-oci-orm/modules/logging/variables.tf
@@ -1,3 +1,9 @@
+variable "freeform_tags" {
+  type        = map(string)
+  description = "A map of freeform tags to apply to the resources"
+  default     = {}
+}
+
 variable "compartment_ocid" {
   type        = string
   description = "The OCID of the compartment where resources exist"
@@ -16,5 +22,16 @@ variable "resources" {
     groupId       = string
     identifier    = string
     resourceType  = string
+    timeCreated   = string
+  }))
+}
+
+variable "logs_map" {
+  description = "All Log Objects present globally"
+  type = map(object({
+    loggroupid = string
+    state      = string
+    is_enabled = string
+    compartmentid = string
   }))
 }

--- a/datadog-logs-oci-orm/modules/logging/variables.tf
+++ b/datadog-logs-oci-orm/modules/logging/variables.tf
@@ -1,0 +1,20 @@
+variable "compartment_ocid" {
+  type        = string
+  description = "The OCID of the compartment where resources exist"
+}
+
+variable "service_map" {
+  description = "A map of service names to a list of associated log categories."
+  type = map(list(string))
+}
+
+variable "resources" {
+  description = "A list of resource objects, each with compartmentId, displayName, groupId, identifier, and resourceType."
+  type = list(object({
+    compartmentId = string
+    displayName   = string
+    groupId       = string
+    identifier    = string
+    resourceType  = string
+  }))
+}

--- a/datadog-logs-oci-orm/modules/logging/variables.tf
+++ b/datadog-logs-oci-orm/modules/logging/variables.tf
@@ -30,8 +30,3 @@ variable "resources" {
     timeCreated   = string
   }))
 }
-
-variable "enable_audit_log_forwarding" {
-  type        = bool
-  description = "Enable forwarding of audit logs to Datadog"
-}

--- a/datadog-logs-oci-orm/modules/logging/variables.tf
+++ b/datadog-logs-oci-orm/modules/logging/variables.tf
@@ -4,6 +4,11 @@ variable "freeform_tags" {
   default     = {}
 }
 
+variable "tenancy_ocid" {
+  type        = string
+  description = "OCI tenant OCID, more details can be found at https://docs.cloud.oracle.com/en-us/iaas/Content/API/Concepts/apisigningkey.htm#five"
+}
+
 variable "compartment_ocid" {
   type        = string
   description = "The OCID of the compartment where resources exist"
@@ -23,15 +28,5 @@ variable "resources" {
     identifier    = string
     resourceType  = string
     timeCreated   = string
-  }))
-}
-
-variable "logs_map" {
-  description = "All Log Objects present globally"
-  type = map(object({
-    loggroupid = string
-    state      = string
-    is_enabled = string
-    compartmentid = string
   }))
 }

--- a/datadog-logs-oci-orm/modules/policy/locals.tf
+++ b/datadog-logs-oci-orm/modules/policy/locals.tf
@@ -1,4 +1,4 @@
 locals {
-  dynamic_group_name = "${var.resource_name_prefix}-sch-dg"
-  policy_name     = "${var.resource_name_prefix}-sch-policy"
+  dynamic_group_name = "datadog-logs-dynamic-group"
+  policy_name     = "datadog-logs-policy"
 }

--- a/datadog-logs-oci-orm/modules/policy/main.tf
+++ b/datadog-logs-oci-orm/modules/policy/main.tf
@@ -15,9 +15,9 @@ resource "oci_identity_policy" "logs_policy" {
   compartment_id = var.tenancy_ocid
   description    = "[DO NOT REMOVE] Policy to have any connector hub read from logging source and write to a target function"
   name           = local.policy_name
-  statements = ["Allow dynamic-group ${local.dynamic_group_name} to read log-content in tenancy",
-    "Allow dynamic-group ${local.dynamic_group_name} to use fn-function in tenancy",
-    "Allow dynamic-group ${local.dynamic_group_name} to use fn-invocation in tenancy"
+  statements = ["Allow dynamic-group Default/${local.dynamic_group_name} to read log-content in tenancy",
+    "Allow dynamic-group Default/${local.dynamic_group_name} to use fn-function in tenancy",
+    "Allow dynamic-group Default/${local.dynamic_group_name} to use fn-invocation in tenancy"
   ]
   defined_tags  = {}
   freeform_tags = var.freeform_tags

--- a/datadog-logs-oci-orm/modules/policy/variables.tf
+++ b/datadog-logs-oci-orm/modules/policy/variables.tf
@@ -8,8 +8,3 @@ variable "freeform_tags" {
   description = "A map of freeform tags to apply to the resources"
   default     = {}
 }
-
-variable "resource_name_prefix" {
-  type        = string
-  description = "The prefix for the name of all of the resources"
-}

--- a/datadog-logs-oci-orm/modules/resourcediscovery/search_resources.sh
+++ b/datadog-logs-oci-orm/modules/resourcediscovery/search_resources.sh
@@ -39,7 +39,7 @@ for rt in "${types[@]}"; do
         next_page=$(echo "$response" | jq -r '."opc-next-page" // "null"')
 
         # Extract and transform items
-        items=$(echo "$response" | jq --arg group_id "$GROUP_ID" -c '[.data.items[] | {compartmentId: ."compartment-id", displayName: ."display-name", identifier: ."identifier", resourceType: ."resource-type", groupId: $group_id}]')
+        items=$(echo "$response" | jq --arg group_id "$GROUP_ID" -c '[.data.items[] | {compartmentId: ."compartment-id", displayName: ."display-name", identifier: ."identifier", resourceType: (."resource-type" | ascii_downcase), groupId: $group_id}]')
         # Append items to the output file if not empty
         if [ "$(echo "$items" | jq length)" -gt 0 ]; then
             temp_items_file="temp_items_$${GROUP_ID}_$${COMPARTMENT_ID}.json"

--- a/datadog-logs-oci-orm/modules/resourcediscovery/search_resources.sh
+++ b/datadog-logs-oci-orm/modules/resourcediscovery/search_resources.sh
@@ -18,12 +18,12 @@ for rt in "${types[@]}"; do
         if [ "$next_page" == "init" ]; then
             # First query without next page token
             response=$(oci search resource structured-search --query-text \
-                "QUERY $rt resources where compartmentId = '$COMPARTMENT_ID' && lifeCycleState != 'TERMINATED' && lifeCycleState != 'FAILED'" \
+                "QUERY $rt resources where compartmentId = '$COMPARTMENT_ID' && (lifeCycleState = 'ACTIVE' || lifeCycleState = 'AVAILABLE' || lifeCycleState = 'RUNNING')" \
                 --output json)
         else
             # Query with next page token
             response=$(oci search resource structured-search --query-text \
-                "QUERY $rt resources where compartmentId = '$COMPARTMENT_ID' && lifeCycleState != 'TERMINATED' && lifeCycleState != 'FAILED'" \
+                "QUERY $rt resources where compartmentId = '$COMPARTMENT_ID' && (lifeCycleState = 'ACTIVE' || lifeCycleState = 'AVAILABLE' || lifeCycleState = 'RUNNING')" \
                 --page "$next_page" \
                 --output json)
         fi
@@ -39,7 +39,7 @@ for rt in "${types[@]}"; do
         next_page=$(echo "$response" | jq -r '."opc-next-page" // "null"')
 
         # Extract and transform items
-        items=$(echo "$response" | jq --arg group_id "$GROUP_ID" -c '[.data.items[] | {compartmentId: ."compartment-id", displayName: ."display-name", identifier: ."identifier", resourceType: (."resource-type" | ascii_downcase), groupId: $group_id}]')
+        items=$(echo "$response" | jq --arg group_id "$GROUP_ID" -c '[.data.items[] | {compartmentId: ."compartment-id", displayName: ."display-name", identifier: ."identifier", resourceType: (."resource-type" | ascii_downcase), groupId: $group_id, timeCreated: (."defined-tags"."Oracle-Tags"."CreatedOn" // ."time-created")}]')
         # Append items to the output file if not empty
         if [ "$(echo "$items" | jq length)" -gt 0 ]; then
             temp_items_file="temp_items_$${GROUP_ID}_$${COMPARTMENT_ID}.json"

--- a/datadog-logs-oci-orm/outputs.tf
+++ b/datadog-logs-oci-orm/outputs.tf
@@ -1,4 +1,3 @@
-/*
 output "vcn_network_details" {
   description = "Output of VCN Network Details"
   value = module.vcn.vcn_network_details
@@ -23,7 +22,7 @@ output "function_details" {
   description = "Output of function creation"
   value = module.function.function_details
 }
-*/
+
 output "logging_details" {
   description = "Output of logging details"
   value = {

--- a/datadog-logs-oci-orm/outputs.tf
+++ b/datadog-logs-oci-orm/outputs.tf
@@ -1,3 +1,4 @@
+
 output "vcn_network_details" {
   description = "Output of VCN Network Details"
   value = module.vcn.vcn_network_details
@@ -13,7 +14,6 @@ output "function_app_details" {
   value = module.functionapp.function_app_details
 }
 
-
 output "containerregistry_details" {
   description = "Output of Pushing Function image to Container registry"
   value = length(module.containerregistry) > 0 ? module.containerregistry[0].containerregistry_details : null
@@ -24,8 +24,9 @@ output "function_details" {
   value = module.function.function_details
 }
 
-output "resources" {
-    value = {
-      for k, v in module.resourcediscovery : k => v.response if length(v.response) > 0
+output "logging_details" {
+  description = "Output of logging details"
+  value = {
+      for k, v in module.logging : k => v.details if length(v.details) > 0
     }
 }

--- a/datadog-logs-oci-orm/outputs.tf
+++ b/datadog-logs-oci-orm/outputs.tf
@@ -15,7 +15,7 @@ output "function_app_details" {
 
 output "containerregistry_details" {
   description = "Output of Pushing Function image to Container registry"
-  value = length(module.containerregistry) > 0 ? module.containerregistry[0].containerregistry_details : null
+  value = module.containerregistry.containerregistry_details
 }
 
 output "function_details" {
@@ -26,6 +26,11 @@ output "function_details" {
 output "logging_details" {
   description = "Output of logging details"
   value = {
-      for k, v in module.logging : k => v.details if length(v.details) > 0
+      for k, v in module.logging : k => v.details
     }
+}
+
+output "connectorhub_details" {
+  description = "Output of connector hub details"
+  value = module.connectorhub.connectorhub_details
 }

--- a/datadog-logs-oci-orm/outputs.tf
+++ b/datadog-logs-oci-orm/outputs.tf
@@ -1,5 +1,3 @@
-
-/*
 output "vcn_network_details" {
   description = "Output of VCN Network Details"
   value = module.vcn.vcn_network_details
@@ -24,7 +22,7 @@ output "function_details" {
   description = "Output of function creation"
   value = module.function.function_details
 }
-*/
+
 output "logging_details" {
   description = "Output of logging details"
   value = {

--- a/datadog-logs-oci-orm/outputs.tf
+++ b/datadog-logs-oci-orm/outputs.tf
@@ -1,3 +1,4 @@
+/*
 output "vcn_network_details" {
   description = "Output of VCN Network Details"
   value = module.vcn.vcn_network_details
@@ -22,7 +23,7 @@ output "function_details" {
   description = "Output of function creation"
   value = module.function.function_details
 }
-
+*/
 output "logging_details" {
   description = "Output of logging details"
   value = {

--- a/datadog-logs-oci-orm/outputs.tf
+++ b/datadog-logs-oci-orm/outputs.tf
@@ -1,4 +1,5 @@
 
+/*
 output "vcn_network_details" {
   description = "Output of VCN Network Details"
   value = module.vcn.vcn_network_details
@@ -23,7 +24,7 @@ output "function_details" {
   description = "Output of function creation"
   value = module.function.function_details
 }
-
+*/
 output "logging_details" {
   description = "Output of logging details"
   value = {

--- a/datadog-logs-oci-orm/schema.yaml
+++ b/datadog-logs-oci-orm/schema.yaml
@@ -11,7 +11,6 @@ variableGroups:
       - ${tenancy_ocid}
       - ${region}
       - ${compartment_ocid}
-      - ${current_user_ocid}
   - title: "Network options"
     variables:
       - ${create_vcn}
@@ -25,27 +24,15 @@ variableGroups:
       - ${datadog_tags}
   - title: "Function settings"
     variables:
-      - ${function_app_shape}
-      - ${create_new_function_image}
-      - ${function_image_path}
-  - title: "Container Registry"
-    variables:
-      - ${use_different_service_user}
-      - ${service_user_ocid}
-      - ${create_auth_token}
-      - ${auth_token_description}
-      - ${auth_token}
-    visible: ${create_new_function_image}
+      - ${oci_docker_username}
+      - ${oci_docker_password}
   - title: "Logging"
     variables:
-      - ${exclude_services}
+      - ${include_services}
       - ${logging_compartments_csv}
       - ${enable_audit_log_forwarding}
 
 variables:
-  current_user_ocid:
-    visible: false
-  
   tenancy_ocid:
       visible: false
 
@@ -120,82 +107,29 @@ variables:
     confirmation: true
 
 # Function setup
-  function_app_shape:
-    title: Function Application shape
-    type: enum
-    description: The shape of the function application. The docker image should be built accordingly. Use GENERIC_ARM if using Oracle Resource manager stack.
-    required: true
-    enum:
-      - GENERIC_ARM
-      - GENERIC_X86
-      - GENERIC_X86_ARM
-    default: GENERIC_ARM
-  
-  create_new_function_image:
-    title: Create New Function Image
-    description: Variable to create new function image. Otherwise, choose an existing image.
-    required: true
-    type: boolean
-    default: true
-
-  function_image_path:
-    title: Function Image Path
+  oci_docker_username:
+    title: OCI Docker registry user name
     type: string
+    description: The user login for the OCI docker container registry to push function image.
     required: true
-    description: The full path of the function image. The image should be present in the container registry for the region and be compatible with the function application shape.
-    visible:
-      not:
-        - ${create_new_function_image}
-
-# Container Registry
-  use_different_service_user:
-    title: Use Different Service User
-    description: Option to use a different service user for Docker login and pushing images.
-    type: boolean
-    required: true
-    default: false
-
-  service_user_ocid:
-    title: Service User OCID
-    type: string
-    description: The OCID of the service user to be used for Docker login and pushing images.
-    required: true
-    default: ""
-    visible: ${use_different_service_user}
-
-  create_auth_token:
-    title: Create Auth Token
-    description: Variable to create auth token for the user. Otherwise, choose an existing auth token. If there are already 2 tokens, you need to delete one to create a new one.
-    type: boolean
-    required: true
-    default: false
-    visible: 
-      not:
-        - ${use_different_service_user}
-  
-  auth_token_description:
-    title: Auth Token Description
-    default: datadog-auth-token
-    required: true
-    visible: ${create_auth_token}
-  
-  auth_token:
-    title: Auth Token
-    type: password
-    description: The auth token to be used for the container registry.
     sensitive: true
+  oci_docker_password:
+    title: OCI Docker registry auth token
+    type: password
+    description: The user auth token for the OCI docker container registry. Used in creating function image.
     required: true
-    visible:
-      not:
-        - ${create_auth_token}
+    sensitive: true
 
 #Logging
-  exclude_services:
-    title: Exclude Services from Logging
+  include_services:
+    title: Include Services for Logging
     type: enum
-    description: List of services to exclude from logging.
+    description: List of services to include for logging.
     required: false
-    default: []
+    default:
+      - "flowlogs"
+      - "oke-k8s-cp-prod"
+      - "och"
     additionalProps:
       allowMultiple: true
     enum:
@@ -207,7 +141,6 @@ variables:
       - "cloud_guard_raw_logs_prod"
       - "och"
       - "oke-k8s-cp-prod"
-      - "contentdeliverynetwork"
       - "dataflow"
       - "dataintegration"
       - "datascience"
@@ -219,6 +152,7 @@ variables:
       - "functions"
       - "goldengate"
       - "integration"
+      - "keymanagementservice"
       - "loadbalancer"
       - "mediaflow"
       - "ocinetworkfirewall"
@@ -229,12 +163,14 @@ variables:
       - "flowlogs"
       - "waa"
       - "waf"
-
-  logging_compartments_csv:
-    title: Compartments CSV
-    description: "Upload a CSV file containing the list of compartments. The file must include a column named 'compartment_id'."
-    type: file
+  
+  logging_compartments:
+    title: Logging compartments
+    type: text
     required: true
+    description: The list of logging compartments. Enter comma separated list of OCID of compartments from which logs should be forwarded.
+    default: ${tenancy_ocid}
+    multiline: true
   
   enable_audit_log_forwarding:
     title: Enable Audit Log Forwarding

--- a/datadog-logs-oci-orm/schema.yaml
+++ b/datadog-logs-oci-orm/schema.yaml
@@ -40,6 +40,7 @@ variableGroups:
     variables:
       - ${exclude_services}
       - ${logging_compartments_csv}
+      - ${enable_audit_log_forwarding}
 
 variables:
   current_user_ocid:
@@ -234,3 +235,10 @@ variables:
     description: "Upload a CSV file containing the list of compartments. The file must include a column named 'compartment_id'."
     type: file
     required: true
+  
+  enable_audit_log_forwarding:
+    title: Enable Audit Log Forwarding
+    description: Enable forwarding of audit logs for selected compartments to Datadog.
+    type: boolean
+    required: true
+    default: false

--- a/datadog-logs-oci-orm/variables.tf
+++ b/datadog-logs-oci-orm/variables.tf
@@ -124,3 +124,9 @@ variable "logging_compartments_csv" {
   description = "Base64-encoded CSV file containing compartment IDs."
   type        = string
 }
+
+variable "enable_audit_log_forwarding" {
+  type        = bool
+  default     = false
+  description = "Enable forwarding of audit logs to Datadog"
+}

--- a/datadog-logs-oci-orm/variables.tf
+++ b/datadog-logs-oci-orm/variables.tf
@@ -42,30 +42,6 @@ variable "tenancy_ocid" {
   description = "OCI tenant OCID, more details can be found at https://docs.cloud.oracle.com/en-us/iaas/Content/API/Concepts/apisigningkey.htm#five"
 }
 
-variable "current_user_ocid" {
-  type        = string
-  description = "OCID of the logged in user running the terraform script"
-}
-
-#************************************
-#   Function Application Variables   
-#************************************
-variable "function_app_shape" {
-  type        = string
-  default     = "GENERIC_ARM"
-  description = "The shape of the function application. The docker image should be built accordingly. Use ARM if using Oracle Resource manager stack"
-  validation {
-    condition     = contains(["GENERIC_ARM", "GENERIC_X86", "GENERIC_X86_ARM"], var.function_app_shape)
-    error_message = "Valid values are: GENERIC_ARM, GENERIC_X86, GENERIC_X86_ARM."
-  }
-}
-
-variable "function_image_path" {
-  type        = string
-  default     = ""
-  description = "The full path of the function image. The image should be present in the container registry for the region"
-}
-
 #*************************************
 #         Datadog Variables
 #*************************************
@@ -90,39 +66,32 @@ variable "datadog_tags" {
 }
 
 #************************************
-#    Container Registry Variables    
+#    Function setup Variables    
 #************************************
-variable "auth_token_description" {
-  description = "The description of the auth token to use for container registry login"
+variable "oci_docker_username" {
   type        = string
-  default     = "datadog-auth-token"
-}
-
-variable "auth_token" {
-  type        = string
-  default     = ""
   sensitive   = true
-  description = "The user auth token for docker login to OCI container registry."
+  description = "The docker login username for the OCI container registry. Used in creating function image."
 }
 
-variable "service_user_ocid" {
+variable "oci_docker_password" {
   type        = string
-  default     = ""
-  description = "The OCID of the service user to be used for Docker login and pushing images."
+  sensitive   = true
+  description = "The user auth token for the OCI docker container registry. Used in creating function image."
 }
 
 #***************
 #    Logging    
 #***************
-variable "exclude_services" {
+variable "include_services" {
   type        = list(string)
   default     = []
-  description = "List of services to be excluded from logging"
+  description = "List of services to be included in logging"
 }
 
-variable "logging_compartments_csv" {
-  description = "Base64-encoded CSV file containing compartment IDs."
+variable "logging_compartments" {
   type        = string
+  description = "The comma separated list of compartments OCID to collect logs."
 }
 
 variable "enable_audit_log_forwarding" {


### PR DESCRIPTION
## What

- Get All log groups in tenancy, and get all logs from log groups. This is required because log resources for resources from which we want to forward logs maybe present in other compartments.
- Add timeCreated field for resources in discovery. This helps add deterministic behavior for log creation
- Add logging module
1. It takes in resources from which logs should be forwarded for a compartment, all existing log resources in tenancy and services from which logs need to be forwarded.
2. It finds existing loggroups from which logs should be forwarded.
3. It creates a new log group "datadog-service-logs" in the compartment.
4. It generates log resources for resources which don't have logging already enabled.
5. It outputs existing loggroups and loggroup id for the newly created "datadog-service-logs" group.

## Why

- Setting up infrastructure for log forwarding

## Testing
1. Base Case : [Stack Link](https://cloud.oracle.com/resourcemanager/stacks/ocid1.ormstack.oc1.iad.amaaaaaaehwejaia2omroquti6lnffz5noxv6hsziorgzlp775u3brb7gekq?region=us-ashburn-1&cloudshell=true&bdcstate=minimized)
2. Re-execution of stack with more compartments: If more compartments are added in compartments csv and stack is reexecuted, logs from new compartments will be generated, and nothing will happen to existing log resources.
3. Re-execution of stack with no variables changed: New resources generated since the last execution will be found, and log forwarding will be setup from these new resources
4. Re-execution of stack with change in exclude_services variable : This should also be honored correctly, although we might regenerate some log resources in this case. 

### Issues Fixed During Testing

- Display Name of resource may have a space. To derive log resource display name from resource name, replace " " with "_".
- Resource Types from resourcediscovery may be Camelcase. Make them lower case to match existing log resources.
- Objectstorage is a special case requiring resource.display_name instead of resource.id, in order to generate logging resource.
- If there is a log-category = "all", we can't enable specific categories. For example, for flowlogs, categories = ["all", "flowlogs"]. We only need to enable logs of "all" category, which collects information for the entire service. This is now handled in the code.