### PR TITLE
ECI-418 Change the auth user email for DatadogAuthUser

### DIFF
--- a/datadog-oci-orm/policy-setup/policy.tf
+++ b/datadog-oci-orm/policy-setup/policy.tf
@@ -41,7 +41,7 @@ resource "oci_identity_user" "read_only_user" {
     compartment_id = var.tenancy_ocid
     description = "[DO NOT REMOVE] Read only user created for fetching resources metadata which is used by Datadog Integrations"
     name = "DatadogAuthUser"
-    email = "test@test.com"
+    email = "test@datadoghq.com"
 
     #Optional
     defined_tags = {}


### PR DESCRIPTION
**what:**
* Change the email of DatadogAuthUser to `datadoghq` domain.

**why:**
* For security reason. To avoid sending the user creation email to a known email domain
* Currently releasing with this email as a quick fix. TBC with internal compliance on the best course of action.