### PR TITLE
ECI-398 Add connectorhub module

### DIFF
--- a/datadog-logs-oci-orm/locals.tf
+++ b/datadog-logs-oci-orm/locals.tf
@@ -6,13 +6,7 @@ locals {
 }
 
 locals {
-  # Decode the uploaded CSV file into a map
-  logging_csv_content = base64decode(var.logging_compartments_csv)
-  logging_compartments = csvdecode(local.logging_csv_content)
-
-  logging_compartment_ids = toset([
-    for row in local.logging_compartments : row.compartment_id
-  ])
+  logging_compartment_ids = toset(split(",", var.logging_compartments))
 
   # Parse the content from the external data source
   logging_services = jsondecode(data.external.logging_services.result["content"])
@@ -20,7 +14,7 @@ locals {
   # Filter services to exclude those in exclude_services
   filtered_services = [
     for service in local.logging_services : service
-    if !contains(var.exclude_services, service.id)
+    if contains(var.include_services, service.id)
   ]
 
   # Generate a Cartesian product of compartments and filtered services

--- a/datadog-logs-oci-orm/locals.tf
+++ b/datadog-logs-oci-orm/locals.tf
@@ -130,7 +130,7 @@ locals {
   datadog_service_log_groups = [
     for compartment_id, value in module.logging : 
       {
-        log_group_id = value.details.datadog_service_loggroup_id
+        log_group_id = try(value.details.datadog_service_log_group_id, null)
         compartment_id     = compartment_id
       }
       if try(value.details.datadog_service_log_group_id, null) != null

--- a/datadog-logs-oci-orm/locals.tf
+++ b/datadog-logs-oci-orm/locals.tf
@@ -119,3 +119,33 @@ locals {
     )
   })
 }
+
+locals {
+  preexisting_service_log_groups = flatten([
+    for compartment_id, value in module.logging : 
+      value.details.preexisting_log_groups
+  ])
+  
+  # Extract service log groups if they are not null
+  datadog_service_log_groups = [
+    for compartment_id, value in module.logging : 
+      {
+        log_group_id = value.details.datadog_service_loggroup_id
+        compartment_id     = compartment_id
+      }
+      if try(value.details.datadog_service_log_group_id, null) != null
+  ]
+
+  service_log_groups = toset(concat(local.preexisting_service_log_groups, local.datadog_service_log_groups))
+
+  # Extract audit log groups if they are not null
+  audit_log_groups = toset([
+    for compartment_id, value in module.logging : 
+      {
+        log_group_id = value.details.audit_log_group_id
+        compartment_id     = compartment_id
+      }
+      if value.details.audit_log_group_id != null 
+  ])
+  
+}

--- a/datadog-logs-oci-orm/main.tf
+++ b/datadog-logs-oci-orm/main.tf
@@ -65,3 +65,14 @@ module "logging" {
     resources = flatten(lookup(local.compartment_resources,each.value,[]))
     enable_audit_log_forwarding = local.logging_configurations[each.value].enable_audit_log_forwarding
 }
+
+module "connectorhub" {
+    source = "./modules/connectorhub"
+    freeform_tags = local.freeform_tags
+    compartment_ocid = var.compartment_ocid
+    resource_name_prefix = var.resource_name_prefix
+    #function_ocid = module.function.function_details.function_ocid
+    function_ocid = ""
+    service_log_groups = local.service_log_groups
+    audit_log_groups = local.audit_log_groups
+}

--- a/datadog-logs-oci-orm/main.tf
+++ b/datadog-logs-oci-orm/main.tf
@@ -10,7 +10,6 @@ module "vcn" {
 module "policy" {
     source = "./modules/policy"
     tenancy_ocid = var.tenancy_ocid
-    resource_name_prefix = var.resource_name_prefix
     freeform_tags = local.freeform_tags
 }
 
@@ -19,7 +18,6 @@ module "functionapp" {
     compartment_ocid = var.compartment_ocid
     freeform_tags = local.freeform_tags
     resource_name_prefix = var.resource_name_prefix
-    function_app_shape = var.function_app_shape
     subnet_ocid = module.vcn.vcn_network_details.subnet_id
     datadog_api_key = var.datadog_api_key
     datadog_endpoint = var.datadog_endpoint
@@ -30,13 +28,11 @@ module "containerregistry" {
     source = "./modules/containerregistry"
     region = var.region
     tenancy_ocid = var.tenancy_ocid
-    user_ocid = var.service_user_ocid == "" ? var.current_user_ocid : var.service_user_ocid
-    auth_token_description = var.auth_token_description
-    auth_token = var.auth_token
+    username = var.oci_docker_username
+    auth_token = var.oci_docker_password
     resource_name_prefix = var.resource_name_prefix
     compartment_ocid = var.compartment_ocid
     freeform_tags = local.freeform_tags
-    count = var.function_image_path == "" ? 1 : 0
 }
 
 module "function" {
@@ -45,7 +41,7 @@ module "function" {
     freeform_tags = local.freeform_tags
     function_app_name = module.functionapp.function_app_details.function_app_name
     function_app_ocid = module.functionapp.function_app_details.function_app_ocid
-    function_image_path = var.function_image_path == "" ? module.containerregistry[0].containerregistry_details.function_image_path : var.function_image_path
+    function_image_path = module.containerregistry.containerregistry_details.function_image_path
 }
 
 module "resourcediscovery" {

--- a/datadog-logs-oci-orm/main.tf
+++ b/datadog-logs-oci-orm/main.tf
@@ -1,4 +1,3 @@
-/*
 module "vcn" {
     source = "./modules/vcn"
     compartment_ocid = var.vcn_compartment
@@ -48,7 +47,7 @@ module "function" {
     function_app_ocid = module.functionapp.function_app_details.function_app_ocid
     function_image_path = var.function_image_path == "" ? module.containerregistry[0].containerregistry_details.function_image_path : var.function_image_path
 }
-*/
+
 module "resourcediscovery" {
     for_each = { for target in local.logging_targets : "${target.compartment_id}_${target.service_id}" => target }
     source = "./modules/resourcediscovery"
@@ -71,8 +70,7 @@ module "connectorhub" {
     freeform_tags = local.freeform_tags
     compartment_ocid = var.compartment_ocid
     resource_name_prefix = var.resource_name_prefix
-    #function_ocid = module.function.function_details.function_ocid
-    function_ocid = "ocid1.fnfunc.oc1.iad.aaaaaaaaj6hnervgi25aviy3bu254qd6u2i7fwye3vkiubmiuksgvrtijjdq"
+    function_ocid = module.function.function_details.function_ocid
     service_log_groups = local.service_log_groups
     audit_log_compartments = var.enable_audit_log_forwarding ? local.logging_compartment_ids : []
 }

--- a/datadog-logs-oci-orm/main.tf
+++ b/datadog-logs-oci-orm/main.tf
@@ -1,3 +1,4 @@
+/*
 module "vcn" {
     source = "./modules/vcn"
     compartment_ocid = var.vcn_compartment
@@ -47,7 +48,7 @@ module "function" {
     function_app_ocid = module.functionapp.function_app_details.function_app_ocid
     function_image_path = var.function_image_path == "" ? module.containerregistry[0].containerregistry_details.function_image_path : var.function_image_path
 }
-
+*/
 module "resourcediscovery" {
     for_each = { for target in local.logging_targets : "${target.compartment_id}_${target.service_id}" => target }
     source = "./modules/resourcediscovery"
@@ -57,13 +58,12 @@ module "resourcediscovery" {
 }
 
 module "logging" {
-    for_each = toset(keys(local.logging_configurations))
+    for_each = local.logging_compartment_ids
     source = "./modules/logging"
     tenancy_ocid = var.tenancy_ocid
     compartment_ocid = each.value
     service_map = local.service_map
     resources = flatten(lookup(local.compartment_resources,each.value,[]))
-    enable_audit_log_forwarding = local.logging_configurations[each.value].enable_audit_log_forwarding
 }
 
 module "connectorhub" {
@@ -71,7 +71,8 @@ module "connectorhub" {
     freeform_tags = local.freeform_tags
     compartment_ocid = var.compartment_ocid
     resource_name_prefix = var.resource_name_prefix
-    function_ocid = module.function.function_details.function_ocid
+    #function_ocid = module.function.function_details.function_ocid
+    function_ocid = "ocid1.fnfunc.oc1.iad.aaaaaaaaj6hnervgi25aviy3bu254qd6u2i7fwye3vkiubmiuksgvrtijjdq"
     service_log_groups = local.service_log_groups
-    audit_log_groups = local.audit_log_groups
+    audit_log_compartments = var.enable_audit_log_forwarding ? local.logging_compartment_ids : []
 }

--- a/datadog-logs-oci-orm/main.tf
+++ b/datadog-logs-oci-orm/main.tf
@@ -71,8 +71,7 @@ module "connectorhub" {
     freeform_tags = local.freeform_tags
     compartment_ocid = var.compartment_ocid
     resource_name_prefix = var.resource_name_prefix
-    #function_ocid = module.function.function_details.function_ocid
-    function_ocid = ""
+    function_ocid = module.function.function_details.function_ocid
     service_log_groups = local.service_log_groups
     audit_log_groups = local.audit_log_groups
 }

--- a/datadog-logs-oci-orm/modules/connectorhub/locals.tf
+++ b/datadog-logs-oci-orm/modules/connectorhub/locals.tf
@@ -1,0 +1,5 @@
+locals {
+  # Names for the service connector
+  service_connector_name = "${var.resource_name_prefix}-service-logs-connector"
+  audit_connector_name = "${var.resource_name_prefix}-service-audit-connector"
+}

--- a/datadog-logs-oci-orm/modules/connectorhub/locals.tf
+++ b/datadog-logs-oci-orm/modules/connectorhub/locals.tf
@@ -1,5 +1,5 @@
 locals {
   # Names for the service connector
   service_connector_name = "${var.resource_name_prefix}-service-logs-connector"
-  audit_connector_name = "${var.resource_name_prefix}-service-audit-connector"
+  audit_connector_name = "${var.resource_name_prefix}-audit-logs-connector"
 }

--- a/datadog-logs-oci-orm/modules/connectorhub/main.tf
+++ b/datadog-logs-oci-orm/modules/connectorhub/main.tf
@@ -1,0 +1,53 @@
+resource "oci_sch_service_connector" "service_log_connector" {
+    compartment_id = var.compartment_ocid
+    display_name   = local.service_connector_name
+    description    = "Terraform created connector hub to distribute service logs"
+
+    source {
+        kind = "logging"
+        dynamic "log_sources" {
+            for_each = var.service_log_groups
+            content {
+                compartment_id = log_sources.value.compartment_id
+                log_group_id   = log_sources.value.log_group_id
+            }
+        }
+    }
+
+    target {
+        kind              = "functions"
+        batch_size_in_kbs = 5000
+        batch_time_in_sec = 60
+        function_id       = var.function_ocid
+    }
+
+    freeform_tags = var.freeform_tags
+}
+
+# Audit Log Connector
+resource "oci_sch_service_connector" "audit_log_connector" {
+    count          = length(var.audit_log_groups) > 0 ? 1 : 0
+    compartment_id = var.compartment_ocid
+    display_name   = local.audit_connector_name
+    description    = "Terraform created connector hub to distribute audit logs"
+
+    source {
+        kind = "logging"
+        dynamic "log_sources" {
+            for_each = var.audit_log_groups
+            content {
+                compartment_id = log_sources.value.compartment_id
+                log_group_id   = log_sources.value.log_group_id
+            }
+        }
+    }
+
+    target {
+        kind              = "functions"
+        batch_size_in_kbs = 5000
+        batch_time_in_sec = 60
+        function_id       = var.function_ocid
+    }
+
+    freeform_tags = var.freeform_tags
+}

--- a/datadog-logs-oci-orm/modules/connectorhub/main.tf
+++ b/datadog-logs-oci-orm/modules/connectorhub/main.tf
@@ -26,7 +26,7 @@ resource "oci_sch_service_connector" "service_log_connector" {
 
 # Audit Log Connector
 resource "oci_sch_service_connector" "audit_log_connector" {
-    count          = length(var.audit_log_groups) > 0 ? 1 : 0
+    count          = length(var.audit_log_compartments) > 0 ? 1 : 0
     compartment_id = var.compartment_ocid
     display_name   = local.audit_connector_name
     description    = "Terraform created connector hub to distribute audit logs"
@@ -34,10 +34,10 @@ resource "oci_sch_service_connector" "audit_log_connector" {
     source {
         kind = "logging"
         dynamic "log_sources" {
-            for_each = var.audit_log_groups
+            for_each = var.audit_log_compartments
             content {
-                compartment_id = log_sources.value.compartment_id
-                log_group_id   = log_sources.value.log_group_id
+                compartment_id = log_sources.value
+                log_group_id   = "_Audit"
             }
         }
     }

--- a/datadog-logs-oci-orm/modules/connectorhub/main.tf
+++ b/datadog-logs-oci-orm/modules/connectorhub/main.tf
@@ -1,3 +1,4 @@
+# Service Log Connector
 resource "oci_sch_service_connector" "service_log_connector" {
     compartment_id = var.compartment_ocid
     display_name   = local.service_connector_name

--- a/datadog-logs-oci-orm/modules/connectorhub/output.tf
+++ b/datadog-logs-oci-orm/modules/connectorhub/output.tf
@@ -1,0 +1,9 @@
+output "connectorhub_details" {
+  description = "Output of connector hub"
+  value       = {
+    service_connector_name = oci_sch_service_connector.service_log_connector.display_name
+    service_connector_ocid = oci_sch_service_connector.service_log_connector.id
+    audit_connector_name   = length(oci_sch_service_connector.audit_log_connector) > 0 ? oci_sch_service_connector.audit_log_connector[0].display_name : ""
+    audit_connector_ocid   = length(oci_sch_service_connector.audit_log_connector) > 0 ? oci_sch_service_connector.audit_log_connector[0].id : ""
+  }
+}

--- a/datadog-logs-oci-orm/modules/connectorhub/variables.tf
+++ b/datadog-logs-oci-orm/modules/connectorhub/variables.tf
@@ -21,13 +21,13 @@ variable "function_ocid" {
 
 variable "audit_log_compartments" {
   description = "List of audit log compartments"
-  type = list(string)
+  type        = list(string)
 }
 
 variable "service_log_groups" {
   description = "A list of maps where each map contains details about an audit log group, including the log group ID and the compartment ID where it is located."
   type = list(object({
-    log_group_id = string
-    compartment_id     = string
+    log_group_id   = string
+    compartment_id = string
   }))
 }

--- a/datadog-logs-oci-orm/modules/connectorhub/variables.tf
+++ b/datadog-logs-oci-orm/modules/connectorhub/variables.tf
@@ -1,0 +1,36 @@
+variable "compartment_ocid" {
+  type        = string
+  description = "The OCID of the compartment where resources exist"
+}
+
+variable "freeform_tags" {
+  type        = map(string)
+  description = "A map of freeform tags to apply to the resources"
+  default     = {}
+}
+
+variable "resource_name_prefix" {
+  type        = string
+  description = "The prefix for the name of all of the resources"
+}
+
+variable "function_ocid" {
+  description = "OCID of the function to which logs will be sent"
+  type        = string
+}
+
+variable "audit_log_groups" {
+  description = "A list of maps where each map contains details about an audit log group, including the log group ID and the compartment ID where it is located."
+  type = list(object({
+    log_group_id = string
+    compartment_id     = string
+  }))
+}
+
+variable "service_log_groups" {
+  description = "A list of maps where each map contains details about an audit log group, including the log group ID and the compartment ID where it is located."
+  type = list(object({
+    log_group_id = string
+    compartment_id     = string
+  }))
+}

--- a/datadog-logs-oci-orm/modules/connectorhub/variables.tf
+++ b/datadog-logs-oci-orm/modules/connectorhub/variables.tf
@@ -19,12 +19,9 @@ variable "function_ocid" {
   type        = string
 }
 
-variable "audit_log_groups" {
-  description = "A list of maps where each map contains details about an audit log group, including the log group ID and the compartment ID where it is located."
-  type = list(object({
-    log_group_id = string
-    compartment_id     = string
-  }))
+variable "audit_log_compartments" {
+  description = "List of audit log compartments"
+  type = list(string)
 }
 
 variable "service_log_groups" {

--- a/datadog-logs-oci-orm/modules/containerregistry/data.tf
+++ b/datadog-logs-oci-orm/modules/containerregistry/data.tf
@@ -1,8 +1,3 @@
 data "oci_objectstorage_namespace" "namespace" {
   compartment_id = var.tenancy_ocid
 }
-
-data "oci_identity_user" "docker_user" {
-    #Required
-    user_id = var.user_ocid
-}

--- a/datadog-logs-oci-orm/modules/containerregistry/locals.tf
+++ b/datadog-logs-oci-orm/modules/containerregistry/locals.tf
@@ -5,5 +5,4 @@ locals {
   function_name = "datadog-function-logs"
   repo_name = "${var.resource_name_prefix}-functions/${local.function_name}"
   docker_image_path = "${local.registry_domain}/${local.tenancy_namespace}/${local.repo_name}"
-  username = data.oci_identity_user.docker_user.name
 }

--- a/datadog-logs-oci-orm/modules/containerregistry/login.tf
+++ b/datadog-logs-oci-orm/modules/containerregistry/login.tf
@@ -1,61 +1,11 @@
-resource "null_resource" "recreate_auth_token" {
-    count = "${var.auth_token != "" ? 0 : 1}"
-    provisioner "local-exec" {
-        command = <<EOT
-            #!/bin/bash
-            set -e
-
-            # Step 1: List existing auth tokens
-            echo "Listing existing auth tokens..."
-            existing_token_ocid=$(oci iam auth-token list --user-id ${var.user_ocid} \
-                --query "data[?description=='${var.auth_token_description}'].id | [0]" --raw-output)
-
-            if [ "$existing_token_ocid" != "" ]; then
-                echo "Deleting existing auth token: $existing_token_ocid"
-                oci iam auth-token delete --user-id ${var.user_ocid} --auth-token-id $existing_token_ocid --force
-            else
-                # Check the total number of existing tokens
-                total_tokens=$(oci iam auth-token list --user-id ${var.user_ocid} --query "length(data)" --raw-output)
-                
-                if [ "$total_tokens" -eq 2 ]; then
-                    echo "Error: Total existing tokens are equal to 2. Cannot create a new token."
-                    exit 1
-                fi
-                echo "No existing auth token with description '${var.auth_token_description}' found. Proceeding to create a new one."
-            fi
-
-            # Step 2: Create a new auth token
-            echo "Creating a new auth token..."
-            new_token_value=$(oci iam auth-token create --user-id ${var.user_ocid} \
-                --description "${var.auth_token_description}" --query "data.token" --raw-output)
-
-            # Step 3: Sleep for 30 seconds to ensure token propagation
-            echo "Waiting for 60 seconds to ensure token availability..."
-            sleep 60
-
-            echo $new_token_value > /tmp/new_auth_token.txt
-        EOT
-    }
-    triggers = {
-        always_run = "${timestamp()}"
-    }
-}
-
 resource "null_resource" "Login2OCIR" {
-    depends_on = [null_resource.recreate_auth_token]
     provisioner "local-exec" {
         command = <<EOT
             #!/bin/bash
             set -e
 
-            # Run the current command
-            if [ "${var.auth_token}" != "" ]; then
-                auth_token="${var.auth_token}"
-            else
-                auth_token=$(cat /tmp/new_auth_token.txt && rm -f /tmp/new_auth_token.txt)
-            fi
             for i in {1..5}; do
-                echo "$auth_token" | docker login ${local.registry_domain} --username ${local.tenancy_namespace}/${local.username} --password-stdin && break
+                echo "${var.auth_token}" | docker login ${local.registry_domain} --username ${local.tenancy_namespace}/${var.username} --password-stdin && break
                 echo "Retrying Docker login... attempt $i"
                 sleep 10
             done
@@ -64,7 +14,7 @@ resource "null_resource" "Login2OCIR" {
             if [ $i -eq 5 ]; then
                 echo "Error: Docker login failed after 5 attempts. Trying to login through Oracle Identity Cloud Service"
                 for j in {1..5}; do
-                    echo "$auth_token" | docker login ${local.registry_domain} --username ${local.tenancy_namespace}/oracleidentitycloudservice/$username --password-stdin && break
+                    echo "${var.auth_token}" | docker login ${local.registry_domain} --username ${local.tenancy_namespace}/oracleidentitycloudservice/${var.username} --password-stdin && break
                     echo "Retrying Docker login through Identity service... attempt $j"
                     sleep 5
                 done

--- a/datadog-logs-oci-orm/modules/containerregistry/variables.tf
+++ b/datadog-logs-oci-orm/modules/containerregistry/variables.tf
@@ -3,9 +3,9 @@ variable "tenancy_ocid" {
   description = "OCI tenant OCID, more details can be found at https://docs.cloud.oracle.com/en-us/iaas/Content/API/Concepts/apisigningkey.htm#five"
 }
 
-variable "user_ocid" {
+variable "username" {
   type        = string
-  description = "OCID of the user for managing docker images"
+  description = "Username for managing docker images"
 }
 
 variable "compartment_ocid" {
@@ -27,11 +27,6 @@ variable "resource_name_prefix" {
 variable "region" {
   type        = string
   description = "OCI Region as documented at https://docs.cloud.oracle.com/en-us/iaas/Content/General/Concepts/regions.htm"
-}
-
-variable "auth_token_description" {
-  description = "The description of the auth token to use for container registry login"
-  type        = string
 }
 
 variable "auth_token" {

--- a/datadog-logs-oci-orm/modules/functionapp/main.tf
+++ b/datadog-logs-oci-orm/modules/functionapp/main.tf
@@ -11,7 +11,7 @@ resource "oci_functions_application" "logs_function_app" {
   freeform_tags = var.freeform_tags
   network_security_group_ids = [
   ]
-  shape = var.function_app_shape
+  shape = "GENERIC_ARM"
   subnet_ids = [
     var.subnet_ocid,
   ]

--- a/datadog-logs-oci-orm/modules/functionapp/variables.tf
+++ b/datadog-logs-oci-orm/modules/functionapp/variables.tf
@@ -17,16 +17,6 @@ variable "resource_name_prefix" {
 #************************************
 #   Function Application Variables   
 #************************************
-variable "function_app_shape" {
-  type        = string
-  default     = "GENERIC_ARM"
-  description = "The shape of the function application. The docker image should be built accordingly. Use ARM if using Oracle Resource managaer stack"
-  validation {
-    condition     = contains(["GENERIC_ARM", "GENERIC_X86", "GENERIC_X86_ARM"], var.function_app_shape)
-    error_message = "Valid values are: GENERIC_ARM, GENERIC_X86, GENERIC_X86_ARM."
-  }
-}
-
 variable "subnet_ocid" {
   type        = string
   description = "The OCID of the subnet to be used for the function app"

--- a/datadog-logs-oci-orm/modules/logging/data.tf
+++ b/datadog-logs-oci-orm/modules/logging/data.tf
@@ -6,17 +6,6 @@ data "oci_logging_log_groups" "datadog_log_group" {
     display_name = "datadog-service-logs"
 }
 
-
-data "oci_logging_log_groups" "audit_log_group" {
-    count = var.enable_audit_log_forwarding ? 1 : 0
-
-    #Required
-    compartment_id = var.compartment_ocid
-
-    #Optional
-    display_name = "_Audit"
-}
-
 # Step 1: Fetch all compartments in the tenancy
 data "oci_identity_compartments" "all_compartments" {
   compartment_id = var.tenancy_ocid

--- a/datadog-logs-oci-orm/modules/logging/output.tf
+++ b/datadog-logs-oci-orm/modules/logging/output.tf
@@ -3,6 +3,5 @@ output "details" {
   value       = {
     preexisting_log_groups = local.log_groups
     datadog_service_log_group_id = length(oci_logging_log_group.datadog_service_log_group) > 0 ? oci_logging_log_group.datadog_service_log_group[0].id : null
-    audit_log_group_id = length(data.oci_logging_log_groups.audit_log_group) > 0 ? data.oci_logging_log_groups.audit_log_group[0].id : null
   }
 }

--- a/datadog-logs-oci-orm/modules/logging/output.tf
+++ b/datadog-logs-oci-orm/modules/logging/output.tf
@@ -1,8 +1,8 @@
 output "details" {
   description = "Output of logging"
   value       = {
-    preexisting_loggroups = local.log_groups
-    datadog_service_loggroup_id = length(oci_logging_log_group.datadog_service_log_group) > 0 ? oci_logging_log_group.datadog_service_log_group[0].id : null
+    preexisting_log_groups = local.log_groups
+    datadog_service_log_group_id = length(oci_logging_log_group.datadog_service_log_group) > 0 ? oci_logging_log_group.datadog_service_log_group[0].id : null
     audit_log_group_id = length(data.oci_logging_log_groups.audit_log_group) > 0 ? data.oci_logging_log_groups.audit_log_group[0].id : null
   }
 }

--- a/datadog-logs-oci-orm/modules/logging/search_logs_outside_compartment.sh
+++ b/datadog-logs-oci-orm/modules/logging/search_logs_outside_compartment.sh
@@ -18,7 +18,7 @@ for lgid in "${types[@]}"; do
     if [[ $(echo "$response" | jq 'length') -ne 0 ]]; then
         output_file="${RESOURCE_ID}.json"
         echo "[]" > $output_file # Initialize the output file with an empty JSON array
-        loggroup=$(echo "$response" | jq -c '.[0] | {log_group_id: .id, state: .["lifecycle-state"], is_enabled: .["is-enabled"], compartment_id: .["compartment-id"]}')
+        loggroup=$(echo "$response" | jq -c '.[0] | {log_group_id: .["log-group-id"], state: .["lifecycle-state"], is_enabled: .["is-enabled"], compartment_id: .["compartment-id"]}')
         # Write the response to the output file
         echo "$loggroup" > "$output_file"
         found=true

--- a/datadog-logs-oci-orm/modules/logging/variables.tf
+++ b/datadog-logs-oci-orm/modules/logging/variables.tf
@@ -30,8 +30,3 @@ variable "resources" {
     timeCreated   = string
   }))
 }
-
-variable "enable_audit_log_forwarding" {
-  type        = bool
-  description = "Enable forwarding of audit logs to Datadog"
-}

--- a/datadog-logs-oci-orm/modules/policy/locals.tf
+++ b/datadog-logs-oci-orm/modules/policy/locals.tf
@@ -1,4 +1,4 @@
 locals {
-  dynamic_group_name = "${var.resource_name_prefix}-sch-dg"
-  policy_name     = "${var.resource_name_prefix}-sch-policy"
+  dynamic_group_name = "datadog-logs-dynamic-group"
+  policy_name     = "datadog-logs-policy"
 }

--- a/datadog-logs-oci-orm/modules/policy/main.tf
+++ b/datadog-logs-oci-orm/modules/policy/main.tf
@@ -15,9 +15,9 @@ resource "oci_identity_policy" "logs_policy" {
   compartment_id = var.tenancy_ocid
   description    = "[DO NOT REMOVE] Policy to have any connector hub read from logging source and write to a target function"
   name           = local.policy_name
-  statements = ["Allow dynamic-group ${local.dynamic_group_name} to read log-content in tenancy",
-    "Allow dynamic-group ${local.dynamic_group_name} to use fn-function in tenancy",
-    "Allow dynamic-group ${local.dynamic_group_name} to use fn-invocation in tenancy"
+  statements = ["Allow dynamic-group Default/${local.dynamic_group_name} to read log-content in tenancy",
+    "Allow dynamic-group Default/${local.dynamic_group_name} to use fn-function in tenancy",
+    "Allow dynamic-group Default/${local.dynamic_group_name} to use fn-invocation in tenancy"
   ]
   defined_tags  = {}
   freeform_tags = var.freeform_tags

--- a/datadog-logs-oci-orm/modules/policy/variables.tf
+++ b/datadog-logs-oci-orm/modules/policy/variables.tf
@@ -8,8 +8,3 @@ variable "freeform_tags" {
   description = "A map of freeform tags to apply to the resources"
   default     = {}
 }
-
-variable "resource_name_prefix" {
-  type        = string
-  description = "The prefix for the name of all of the resources"
-}

--- a/datadog-logs-oci-orm/outputs.tf
+++ b/datadog-logs-oci-orm/outputs.tf
@@ -1,4 +1,3 @@
-/*
 output "vcn_network_details" {
   description = "Output of VCN Network Details"
   value = module.vcn.vcn_network_details
@@ -23,7 +22,7 @@ output "function_details" {
   description = "Output of function creation"
   value = module.function.function_details
 }
-*/
+
 output "logging_details" {
   description = "Output of logging details"
   value = {

--- a/datadog-logs-oci-orm/outputs.tf
+++ b/datadog-logs-oci-orm/outputs.tf
@@ -26,6 +26,11 @@ output "function_details" {
 output "logging_details" {
   description = "Output of logging details"
   value = {
-      for k, v in module.logging : k => v.details if length(v.details) > 0
+      for k, v in module.logging : k => v.details
     }
+}
+
+output "connectorhub_details" {
+  description = "Output of connector hub details"
+  value = module.connectorhub.connectorhub_details
 }

--- a/datadog-logs-oci-orm/outputs.tf
+++ b/datadog-logs-oci-orm/outputs.tf
@@ -1,3 +1,4 @@
+/*
 output "vcn_network_details" {
   description = "Output of VCN Network Details"
   value = module.vcn.vcn_network_details
@@ -22,7 +23,7 @@ output "function_details" {
   description = "Output of function creation"
   value = module.function.function_details
 }
-
+*/
 output "logging_details" {
   description = "Output of logging details"
   value = {

--- a/datadog-logs-oci-orm/outputs.tf
+++ b/datadog-logs-oci-orm/outputs.tf
@@ -15,7 +15,7 @@ output "function_app_details" {
 
 output "containerregistry_details" {
   description = "Output of Pushing Function image to Container registry"
-  value = length(module.containerregistry) > 0 ? module.containerregistry[0].containerregistry_details : null
+  value = module.containerregistry.containerregistry_details
 }
 
 output "function_details" {

--- a/datadog-logs-oci-orm/schema.yaml
+++ b/datadog-logs-oci-orm/schema.yaml
@@ -11,7 +11,6 @@ variableGroups:
       - ${tenancy_ocid}
       - ${region}
       - ${compartment_ocid}
-      - ${current_user_ocid}
   - title: "Network options"
     variables:
       - ${create_vcn}
@@ -25,27 +24,15 @@ variableGroups:
       - ${datadog_tags}
   - title: "Function settings"
     variables:
-      - ${function_app_shape}
-      - ${create_new_function_image}
-      - ${function_image_path}
-  - title: "Container Registry"
-    variables:
-      - ${use_different_service_user}
-      - ${service_user_ocid}
-      - ${create_auth_token}
-      - ${auth_token_description}
-      - ${auth_token}
-    visible: ${create_new_function_image}
+      - ${oci_docker_username}
+      - ${oci_docker_password}
   - title: "Logging"
     variables:
-      - ${exclude_services}
+      - ${include_services}
       - ${logging_compartments_csv}
       - ${enable_audit_log_forwarding}
 
 variables:
-  current_user_ocid:
-    visible: false
-  
   tenancy_ocid:
       visible: false
 
@@ -120,82 +107,29 @@ variables:
     confirmation: true
 
 # Function setup
-  function_app_shape:
-    title: Function Application shape
-    type: enum
-    description: The shape of the function application. The docker image should be built accordingly. Use GENERIC_ARM if using Oracle Resource manager stack.
-    required: true
-    enum:
-      - GENERIC_ARM
-      - GENERIC_X86
-      - GENERIC_X86_ARM
-    default: GENERIC_ARM
-  
-  create_new_function_image:
-    title: Create New Function Image
-    description: Variable to create new function image. Otherwise, choose an existing image.
-    required: true
-    type: boolean
-    default: true
-
-  function_image_path:
-    title: Function Image Path
+  oci_docker_username:
+    title: OCI Docker registry user name
     type: string
+    description: The user login for the OCI docker container registry to push function image.
     required: true
-    description: The full path of the function image. The image should be present in the container registry for the region and be compatible with the function application shape.
-    visible:
-      not:
-        - ${create_new_function_image}
-
-# Container Registry
-  use_different_service_user:
-    title: Use Different Service User
-    description: Option to use a different service user for Docker login and pushing images.
-    type: boolean
-    required: true
-    default: false
-
-  service_user_ocid:
-    title: Service User OCID
-    type: string
-    description: The OCID of the service user to be used for Docker login and pushing images.
-    required: true
-    default: ""
-    visible: ${use_different_service_user}
-
-  create_auth_token:
-    title: Create Auth Token
-    description: Variable to create auth token for the user. Otherwise, choose an existing auth token. If there are already 2 tokens, you need to delete one to create a new one.
-    type: boolean
-    required: true
-    default: false
-    visible: 
-      not:
-        - ${use_different_service_user}
-  
-  auth_token_description:
-    title: Auth Token Description
-    default: datadog-auth-token
-    required: true
-    visible: ${create_auth_token}
-  
-  auth_token:
-    title: Auth Token
-    type: password
-    description: The auth token to be used for the container registry.
     sensitive: true
+  oci_docker_password:
+    title: OCI Docker registry auth token
+    type: password
+    description: The user auth token for the OCI docker container registry. Used in creating function image.
     required: true
-    visible:
-      not:
-        - ${create_auth_token}
+    sensitive: true
 
 #Logging
-  exclude_services:
-    title: Exclude Services from Logging
+  include_services:
+    title: Include Services for Logging
     type: enum
-    description: List of services to exclude from logging.
+    description: List of services to include for logging.
     required: false
-    default: []
+    default:
+      - "flowlogs"
+      - "oke-k8s-cp-prod"
+      - "och"
     additionalProps:
       allowMultiple: true
     enum:
@@ -207,7 +141,6 @@ variables:
       - "cloud_guard_raw_logs_prod"
       - "och"
       - "oke-k8s-cp-prod"
-      - "contentdeliverynetwork"
       - "dataflow"
       - "dataintegration"
       - "datascience"
@@ -219,6 +152,7 @@ variables:
       - "functions"
       - "goldengate"
       - "integration"
+      - "keymanagementservice"
       - "loadbalancer"
       - "mediaflow"
       - "ocinetworkfirewall"
@@ -229,12 +163,14 @@ variables:
       - "flowlogs"
       - "waa"
       - "waf"
-
-  logging_compartments_csv:
-    title: Compartments CSV
-    description: "Upload a CSV file containing the list of compartments. The file must include a column named 'compartment_id'."
-    type: file
+  
+  logging_compartments:
+    title: Logging compartments
+    type: text
     required: true
+    description: The list of logging compartments. Enter comma separated list of OCID of compartments from which logs should be forwarded.
+    default: ${tenancy_ocid}
+    multiline: true
   
   enable_audit_log_forwarding:
     title: Enable Audit Log Forwarding

--- a/datadog-logs-oci-orm/variables.tf
+++ b/datadog-logs-oci-orm/variables.tf
@@ -42,30 +42,6 @@ variable "tenancy_ocid" {
   description = "OCI tenant OCID, more details can be found at https://docs.cloud.oracle.com/en-us/iaas/Content/API/Concepts/apisigningkey.htm#five"
 }
 
-variable "current_user_ocid" {
-  type        = string
-  description = "OCID of the logged in user running the terraform script"
-}
-
-#************************************
-#   Function Application Variables   
-#************************************
-variable "function_app_shape" {
-  type        = string
-  default     = "GENERIC_ARM"
-  description = "The shape of the function application. The docker image should be built accordingly. Use ARM if using Oracle Resource manager stack"
-  validation {
-    condition     = contains(["GENERIC_ARM", "GENERIC_X86", "GENERIC_X86_ARM"], var.function_app_shape)
-    error_message = "Valid values are: GENERIC_ARM, GENERIC_X86, GENERIC_X86_ARM."
-  }
-}
-
-variable "function_image_path" {
-  type        = string
-  default     = ""
-  description = "The full path of the function image. The image should be present in the container registry for the region"
-}
-
 #*************************************
 #         Datadog Variables
 #*************************************
@@ -90,39 +66,32 @@ variable "datadog_tags" {
 }
 
 #************************************
-#    Container Registry Variables    
+#    Function setup Variables    
 #************************************
-variable "auth_token_description" {
-  description = "The description of the auth token to use for container registry login"
+variable "oci_docker_username" {
   type        = string
-  default     = "datadog-auth-token"
-}
-
-variable "auth_token" {
-  type        = string
-  default     = ""
   sensitive   = true
-  description = "The user auth token for docker login to OCI container registry."
+  description = "The docker login username for the OCI container registry. Used in creating function image."
 }
 
-variable "service_user_ocid" {
+variable "oci_docker_password" {
   type        = string
-  default     = ""
-  description = "The OCID of the service user to be used for Docker login and pushing images."
+  sensitive   = true
+  description = "The user auth token for the OCI docker container registry. Used in creating function image."
 }
 
 #***************
 #    Logging    
 #***************
-variable "exclude_services" {
+variable "include_services" {
   type        = list(string)
   default     = []
-  description = "List of services to be excluded from logging"
+  description = "List of services to be included in logging"
 }
 
-variable "logging_compartments_csv" {
-  description = "Base64-encoded CSV file containing compartment IDs."
+variable "logging_compartments" {
   type        = string
+  description = "The comma separated list of compartments OCID to collect logs."
 }
 
 variable "enable_audit_log_forwarding" {


### PR DESCRIPTION
## What

- Creates 1 Connector hub for service logs. This connector hub forwards logs from log groups generated to collect service logs
- Creates 1 connector hub for audit logs. This connector hub forward logs from compartments if "Enable Audit Log Forwarding" is selected

## Why
- Set up Infrastructure for Log Forwarding

## Testing

- Logs in DD : [Link](https://app.datadoghq.com/logs?query=source%3Aoci.%2A&agg_m=count&agg_m_source=base&agg_q=status%2Cservice%2Csource&agg_q_source=base%2Cbase%2Cbase&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice%2Csource&fromUser=true&messageDisplay=inline&refresh_mode=paused&sort_m=%2C%2C&sort_m_source=%2C%2C&sort_t=%2C%2C&storage=hot&stream_sort=desc&top_n=10%2C10%2C10&top_o=top%2Ctop%2Ctop&viz=stream&x_missing=true%2Ctrue%2Ctrue&from_ts=1738608423516&to_ts=1738609323516&live=false)
- Stack : [Link](https://cloud.oracle.com/resourcemanager/stacks/ocid1.ormstack.oc1.iad.amaaaaaaehwejaiatwtza3ylwitmoiqebw7wx5xlrcs26f46h2kxcict5adq?region=us-ashburn-1)