### PR TITLE
ECI-446 Handle OCIR repo URL for gov cloud

### DIFF
--- a/datadog-oci-orm/metrics-setup/function_setup.tf
+++ b/datadog-oci-orm/metrics-setup/function_setup.tf
@@ -14,7 +14,7 @@ resource "null_resource" "Login2OCIR" {
            if [ $i -eq 5 ]; then
                echo "Error: Docker login failed after 5 attempts. Trying to login through Oracle Identity Cloud Service"
                for j in {1..5}; do
-                   echo "${var.oci_docker_password}" | docker login ${local.oci_docker_repository} --username ${local.ocir_namespace}/oracleidentitycloudservice/$username --password-stdin && break
+                   echo "${var.oci_docker_password}" | docker login ${local.oci_docker_repository} --username ${local.ocir_namespace}/oracleidentitycloudservice/${var.oci_docker_username} --password-stdin && break
                    echo "Retrying Docker login through Identity service... attempt $j"
                    sleep 5
                done

--- a/datadog-oci-orm/metrics-setup/locals.tf
+++ b/datadog-oci-orm/metrics-setup/locals.tf
@@ -27,12 +27,13 @@ locals {
   })
   oci_region_key      = lower(local.oci_regions[var.region].region_key)
   tenancy_home_region = data.oci_identity_tenancy.tenancy_metadata.home_region_key
+  is_gov_cloud_region = contains(["us-langley-1", "us-luke-1", "us-gov-ashburn-1", "us-gov-chicago-1", "us-gov-phoenix-1"], var.region)
 }
 
 locals {
   # OCI docker repository
-  oci_docker_repository = "${local.oci_region_key}.ocir.io/${local.ocir_namespace}"
-  oci_docker_host       = "${local.oci_region_key}.ocir.io"
+  oci_docker_host       = local.is_gov_cloud_region ? "ocir.${var.region}.oci.oraclegovcloud.com" : "${local.oci_region_key}.ocir.io"
+  oci_docker_repository = "${local.oci_docker_host}/${local.ocir_namespace}"
   ocir_repo_name        = "${var.resource_name_prefix}-functions"
   function_name         = "datadog-function-metrics"
   docker_image_path     = "${local.oci_docker_repository}/${local.ocir_repo_name}/${local.function_name}:latest"


### PR DESCRIPTION
**what:**
* Create docker registry login for ocir regions in a different way

**why:**
* For the docker login in a commercial region, the format used is: `<region-code>.ocir.io`
* The gov regions use canonical endpoints because ocir.io is not supported there.
* The URL in gov region should be: `ocir.$region_name.oci.oraclegovloud.com`
