### PR TITLE
ECI [OCI] add back option to change image shape for metrics

### DIFF
--- a/datadog-oci-orm/metrics-setup/functions.tf
+++ b/datadog-oci-orm/metrics-setup/functions.tf
@@ -15,7 +15,7 @@ resource "oci_functions_application" "metrics_function_app" {
   freeform_tags = local.freeform_tags
   network_security_group_ids = [
   ]
-  shape = "GENERIC_ARM"
+  shape = var.function_app_shape
   subnet_ids = [
     data.oci_core_subnet.input_subnet.id,
   ]

--- a/datadog-oci-orm/metrics-setup/schema.yaml
+++ b/datadog-oci-orm/metrics-setup/schema.yaml
@@ -22,6 +22,7 @@ variableGroups:
       - ${metrics_compartments}
   - title: "Function settings"
     variables:
+      - ${function_app_shape}
       - ${oci_docker_username}
       - ${oci_docker_password}
 
@@ -52,7 +53,7 @@ variables:
   tenancy_ocid:
     required: true
     type: string
-    visible: false        
+    visible: false
 
 # VCN
   vcnCompartment:
@@ -65,7 +66,7 @@ variables:
     type: oci:core:vcn:id
     visible:
       not:
-        - ${create_vcn}    
+        - ${create_vcn}
     dependsOn:
       compartmentId: ${vcnCompartment}
   function_subnet_id:
@@ -144,7 +145,7 @@ variables:
       - "oci_vcn"
       - "oci_vpn"
       - "oci_waf"
-      - "oracle_oci_database"   
+      - "oracle_oci_database"
     enum:
       - "oci_autonomous_database"
       - "oci_blockstore"
@@ -172,9 +173,18 @@ variables:
       - "oci_vpn"
       - "oci_waf"
       - "oracle_oci_database"
-    
+
 
   # Function setup
+  function_app_shape:
+    title: Function Application shape
+    type: enum
+    description: The shape of the function application. The docker image should be built accordingly. Select GENERIC_X86 if there's an error in creating with GENERIC_ARM.
+    required: true
+    enum:
+      - GENERIC_ARM
+      - GENERIC_X86
+    default: GENERIC_ARM
   oci_docker_username:
     title: OCI Docker registry user name
     type: string

--- a/datadog-oci-orm/metrics-setup/variables.tf
+++ b/datadog-oci-orm/metrics-setup/variables.tf
@@ -21,6 +21,16 @@ variable "function_subnet_id" {
   description = "The OCID of the subnet to be used for the function app. If create_vcn is set to true, that will take precedence"
 }
 
+variable "function_app_shape" {
+  type        = string
+  default     = "GENERIC_ARM"
+  description = "The shape of the function application. The docker image should be built accordingly. Select GENERIC_X86 if there's an error in creating with GENERIC_ARM."
+  validation {
+    condition     = contains(["GENERIC_ARM", "GENERIC_X86"], var.function_app_shape)
+    error_message = "Valid values are: GENERIC_ARM, GENERIC_X86."
+  }
+}
+
 variable "datadog_environment" {
   type        = string
   description = "The endpoint to hit for sending the metrics. Varies by different datacenter"


### PR DESCRIPTION
**what:**
Allow customers to specify image shape in metric stack
**why:**
Customers in Japan regions cannot use GENERIC_ARM shape
**testing:**
Ran stack successfully