### PR TITLE
ECI-455 Add service account user for metrics setup and docker images

### DIFF
--- a/datadog-oci-orm/metrics-setup/auth_token.py
+++ b/datadog-oci-orm/metrics-setup/auth_token.py
@@ -1,0 +1,54 @@
+import json
+import sys
+import subprocess
+import traceback
+
+
+def _remove_existing_tokens(token_ids: list, user_ocid: str, region: str) -> None:
+  """
+  Removes existing token if any for a user based on token id list, user_ocid and region
+  """
+  try:
+    for token in token_ids:
+      cmd = ["oci", "iam", "auth-token", "delete", "--auth-token-id", token.strip(), "--user-id", user_ocid, "--region", region, "--force"]
+      subprocess.check_output(cmd, text=True)
+  except subprocess.CalledProcessError as e:
+      raise ChildProcessError(f"Error in removing tokens for user: {user_ocid} {e.output}") from e
+
+
+def _regenerate_token(json_string:str) -> None:
+  """
+  Remove existing tokens and create a new API token. The json string is in the following format.
+  {"user_ocid: "id", "region": "oci_home_region", "token_ids":"t1,t2"}. Token ids are comma separated values.
+  """
+  input_json = json.loads(json_string)
+  user_ocid, region, token_ids = input_json["user_ocid"], input_json["region"], input_json["token_ids"].strip()
+  if token_ids:
+    token_ids = token_ids.split(",")
+    _remove_existing_tokens(token_ids, user_ocid, region)
+  try:
+    cmd = ["oci", "iam", "auth-token", "create", "--user-id", user_ocid, "--description", "autogen token", "--region", region]
+    output = subprocess.check_output(cmd, text=True)
+    result = json.loads(output)["data"]
+    output_data = {"token_id" : result["id"], "token" : result["token"]}
+    json_value = {"output" : json.dumps(output_data)}
+    print(json.dumps(json_value))
+  except subprocess.CalledProcessError as e:
+    raise ChildProcessError(f"Error in creating token for user: {user_ocid} {e.output}") from e
+
+
+if __name__ == "__main__":
+    input_json = sys.stdin.read()
+    if not input_json:
+      print("No Json provided", file=sys.stderr)
+      sys.exit(1)
+    err, trace = None, None
+    try:
+      _regenerate_token(input_json)
+      sys.exit(0)
+    except Exception as e:
+      trace = traceback.format_exc()
+      err = e
+    if trace:
+      print("Error:", err, trace, file=sys.stderr)
+      sys.exit(1)

--- a/datadog-oci-orm/metrics-setup/data.tf
+++ b/datadog-oci-orm/metrics-setup/data.tf
@@ -27,6 +27,7 @@ data "oci_monitoring_metrics" "existing_namespaces" {
 }
 
 data "oci_core_subnet" "input_subnet" {
+  count      = local.is_service_user_available ? 1 : 0
   depends_on = [module.vcn]
   #Required
   subnet_id = var.create_vcn ? module.vcn[0].subnet_id[local.subnet] : var.function_subnet_id

--- a/datadog-oci-orm/metrics-setup/functions.tf
+++ b/datadog-oci-orm/metrics-setup/functions.tf
@@ -1,14 +1,15 @@
 resource "oci_functions_application" "metrics_function_app" {
   depends_on     = [data.oci_core_subnet.input_subnet]
+  count          = local.is_service_user_available ? 1 : 0
   compartment_id = var.compartment_ocid
   config = {
-    "DD_API_KEY"     = var.datadog_api_key
-    "DD_COMPRESS"    = "true"
-    "DD_INTAKE_HOST" = var.datadog_environment
-    "DD_INTAKE_LOGS" = "false"
-    "DD_MAX_POOL"    = "20"
+    "DD_API_KEY"               = var.datadog_api_key
+    "DD_COMPRESS"              = "true"
+    "DD_INTAKE_HOST"           = var.datadog_environment
+    "DD_INTAKE_LOGS"           = "false"
+    "DD_MAX_POOL"              = "20"
     "DETAILED_LOGGING_ENABLED" = "false"
-    "TENANCY_OCID"   = var.tenancy_ocid
+    "TENANCY_OCID"             = var.tenancy_ocid
   }
   defined_tags  = {}
   display_name  = "${var.resource_name_prefix}-function-app"
@@ -17,15 +18,16 @@ resource "oci_functions_application" "metrics_function_app" {
   ]
   shape = var.function_app_shape
   subnet_ids = [
-    data.oci_core_subnet.input_subnet.id,
+    data.oci_core_subnet.input_subnet[0].id,
   ]
 }
 
 resource "oci_functions_function" "metrics_function" {
   depends_on = [oci_functions_application.metrics_function_app, null_resource.wait_for_image]
+  count      = local.is_service_user_available ? 1 : 0
   #Required
-  application_id = oci_functions_application.metrics_function_app.id
-  display_name   = "${oci_functions_application.metrics_function_app.display_name}-metrics-function"
+  application_id = oci_functions_application.metrics_function_app[0].id
+  display_name   = "${oci_functions_application.metrics_function_app[0].display_name}-metrics-function"
   memory_in_mbs  = "256"
 
   #Optional

--- a/datadog-oci-orm/metrics-setup/locals.tf
+++ b/datadog-oci-orm/metrics-setup/locals.tf
@@ -27,6 +27,7 @@ locals {
   })
   oci_region_key      = lower(local.oci_regions[var.region].region_key)
   tenancy_home_region = data.oci_identity_tenancy.tenancy_metadata.home_region_key
+  home_region_name    = [for key, reg in local.oci_regions : reg.region_name if reg.region_key == local.tenancy_home_region][0]
   is_gov_cloud_region = contains(["us-langley-1", "us-luke-1", "us-gov-ashburn-1", "us-gov-chicago-1", "us-gov-phoenix-1"], var.region)
 }
 

--- a/datadog-oci-orm/metrics-setup/outputs.tf
+++ b/datadog-oci-orm/metrics-setup/outputs.tf
@@ -3,7 +3,7 @@
 output "vcn_network_details" {
   depends_on  = [module.vcn]
   description = "Output of the created network infra"
-  value = var.create_vcn ? {
+  value = var.create_vcn && length(module.vcn) > 0 ? {
     vcn_id             = module.vcn[0].vcn_id
     nat_gateway_id     = module.vcn[0].nat_gateway_id
     nat_route_id       = module.vcn[0].nat_route_id
@@ -22,17 +22,22 @@ output "vcn_network_details" {
 
 output "function_application" {
   description = "OCID of the Function app"
-  value       = oci_functions_application.metrics_function_app.id
+  value       = [for app in oci_functions_application.metrics_function_app : app.id]
 }
 
 output "function_application_function" {
   description = "OCID of the Function"
-  value       = oci_functions_function.metrics_function.id
+  value       = [for app in oci_functions_function.metrics_function : app.id]
 }
 
 output "compartment_map" {
   description = "Derived namespaces"
   value       = local.final_namespaces
+}
+
+output "service_account_error" {
+  description = "Message in case service user has not been created."
+  value       = local.is_service_user_available ? "" : "Service user not available to create function images. Please run the policy stack to create the service user."
 }
 
 output "namespace_error" {

--- a/datadog-oci-orm/metrics-setup/schema.yaml
+++ b/datadog-oci-orm/metrics-setup/schema.yaml
@@ -23,8 +23,6 @@ variableGroups:
   - title: "Function settings"
     variables:
       - ${function_app_shape}
-      - ${oci_docker_username}
-      - ${oci_docker_password}
 
 variables:
   resource_name_prefix:
@@ -174,7 +172,6 @@ variables:
       - "oci_waf"
       - "oracle_oci_database"
 
-
   # Function setup
   function_app_shape:
     title: Function Application shape
@@ -185,16 +182,4 @@ variables:
       - GENERIC_ARM
       - GENERIC_X86
     default: GENERIC_ARM
-  oci_docker_username:
-    title: OCI Docker registry user name
-    type: string
-    description: The user login for the OCI docker container registry to push function image. Not required if using an existing image path.
-    required: true
-    sensitive: true
-  oci_docker_password:
-    title: OCI Docker registry auth token
-    type: password
-    description: The user auth token for the OCI docker container registry. Used in creating function image.
-    required: true
-    sensitive: true
 

--- a/datadog-oci-orm/metrics-setup/serviceconnector.tf
+++ b/datadog-oci-orm/metrics-setup/serviceconnector.tf
@@ -1,7 +1,7 @@
 
 # Local variables to manage connector hubs
 locals {
-  metrics_compartments        = toset(split(",", var.metrics_compartments))
+  metrics_compartments        = local.is_service_user_available ? toset(split(",", var.metrics_compartments)) : toset([])
   metrics_compartments_sorted = sort(tolist(local.metrics_compartments))
   supported_namespaces        = var.metrics_namespaces
   # Fetch existing namespaces from the given compartments and intersect with those supported in var.metrics_namespaces
@@ -61,7 +61,7 @@ resource "oci_sch_service_connector" "metrics_service_connector" {
     batch_size_in_kbs = 5000
     batch_time_in_sec = 60
     compartment_id    = var.tenancy_ocid
-    function_id       = oci_functions_function.metrics_function.id
+    function_id       = oci_functions_function.metrics_function[0].id
   }
 
   #Optional

--- a/datadog-oci-orm/metrics-setup/variables.tf
+++ b/datadog-oci-orm/metrics-setup/variables.tf
@@ -41,18 +41,6 @@ variable "datadog_environment" {
   }
 }
 
-variable "oci_docker_username" {
-  type        = string
-  sensitive   = true
-  description = "The docker login username for the OCI container registry. Used in creating function image. Not required if the image is already exists."
-}
-
-variable "oci_docker_password" {
-  type        = string
-  sensitive   = true
-  description = "The user auth token for the OCI docker container registry. Used in creating function image. Not required if the image already exists."
-}
-
 variable "metrics_namespaces" {
   type        = list(string)
   description = "The list of namespaces to collect the metrics for the metrics compartments. Remove any unwanted namespaces."

--- a/datadog-oci-orm/metrics-setup/vcn.tf
+++ b/datadog-oci-orm/metrics-setup/vcn.tf
@@ -2,7 +2,7 @@ module "vcn" {
   depends_on               = [data.oci_objectstorage_namespace.namespace]
   source                   = "oracle-terraform-modules/vcn/oci"
   version                  = "3.6.0"
-  count                    = var.create_vcn ? 1 : 0
+  count                    = var.create_vcn && local.is_service_user_available ? 1 : 0
   compartment_id           = var.compartment_ocid
   defined_tags             = {}
   freeform_tags            = local.freeform_tags

--- a/datadog-oci-orm/policy-setup/policy.tf
+++ b/datadog-oci-orm/policy-setup/policy.tf
@@ -17,8 +17,13 @@ provider "oci" {
 }
 
 locals {
-  tenancy_home_region = data.oci_identity_tenancy.tenancy_metadata.home_region_key
-  read_policy_group = var.dynamic_group_name
+  tenancy_home_region    = data.oci_identity_tenancy.tenancy_metadata.home_region_key
+  datadog_metrics_policy = "datadog-policy-metrics"
+  dd_auth_user           = "DatadogROAuthUser"
+  dd_auth_write_user     = "DatadogAuthWriteUser"
+  dynamic_group_name     = "datadog-dynamic-group"
+  user_group_name        = "DatadogAuthGroup"
+  user_write_group_name  = "DatadogAuthWriteGroup"
   freeform_tags = {
     datadog-terraform = "true"
   }
@@ -29,7 +34,7 @@ resource "oci_identity_dynamic_group" "serviceconnector_group" {
   compartment_id = var.tenancy_ocid
   description    = "[DO NOT REMOVE] Dynamic group for service connector"
   matching_rule  = "All {resource.type = 'serviceconnector'}"
-  name           = var.dynamic_group_name
+  name           = local.dynamic_group_name
 
   #Optional
   defined_tags  = {}
@@ -37,23 +42,47 @@ resource "oci_identity_dynamic_group" "serviceconnector_group" {
 }
 
 resource "oci_identity_user" "read_only_user" {
-    #Required
-    compartment_id = var.tenancy_ocid
-    description = "[DO NOT REMOVE] Read only user created for fetching resources metadata which is used by Datadog Integrations"
-    name = "DatadogAuthUser"
-    email = "test@datadoghq.com"
+  #Required
+  compartment_id = var.tenancy_ocid
+  description    = "[DO NOT REMOVE] Read only user created for fetching resources metadata which is used by Datadog Integrations"
+  name           = local.dd_auth_user
+  email          = "test@datadoghq.com"
 
-    #Optional
-    defined_tags = {}
-    freeform_tags = local.freeform_tags
+  #Optional
+  defined_tags  = {}
+  freeform_tags = local.freeform_tags
+}
+
+resource "oci_identity_user" "write_permissions_user" {
+  #Required
+  compartment_id = var.tenancy_ocid
+  description    = "[DO NOT REMOVE] User for performing write based operations like docker image push"
+  name           = local.dd_auth_write_user
+  email          = "test@oci.com"
+
+  #Optional
+  defined_tags  = {}
+  freeform_tags = local.freeform_tags
 }
 
 resource "oci_identity_group" "read_policy_group" {
-  depends_on     = [oci_identity_user.read_only_user]
+  depends_on = [oci_identity_user.read_only_user]
   #Required
   compartment_id = var.tenancy_ocid
   description    = "[DO NOT REMOVE] Group for adding a user for having read-only permissions of resources"
-  name           = var.user_group_name
+  name           = local.user_group_name
+
+  #Optional
+  defined_tags  = {}
+  freeform_tags = local.freeform_tags
+}
+
+resource "oci_identity_group" "write_user_group" {
+  depends_on = [oci_identity_user.write_permissions_user]
+  #Required
+  compartment_id = var.tenancy_ocid
+  description    = "[DO NOT REMOVE] Group for adding a user for having read-only permissions of resources"
+  name           = local.user_write_group_name
 
   #Optional
   defined_tags  = {}
@@ -61,23 +90,30 @@ resource "oci_identity_group" "read_policy_group" {
 }
 
 resource "oci_identity_user_group_membership" "dd_user_group_membership" {
-    depends_on     = [oci_identity_user.read_only_user, oci_identity_group.read_policy_group]
-    #Required
-    group_id = oci_identity_group.read_policy_group.id
-    user_id = oci_identity_user.read_only_user.id
+  depends_on = [oci_identity_user.read_only_user, oci_identity_group.read_policy_group]
+  #Required
+  group_id = oci_identity_group.read_policy_group.id
+  user_id  = oci_identity_user.read_only_user.id
+}
+
+resource "oci_identity_user_group_membership" "dd_write_user_group_membership" {
+  depends_on = [oci_identity_user.write_permissions_user, oci_identity_group.write_user_group]
+  #Required
+  group_id = oci_identity_group.write_user_group.id
+  user_id  = oci_identity_user.write_permissions_user.id
 }
 
 resource "oci_identity_policy" "metrics_policy" {
   depends_on     = [oci_identity_dynamic_group.serviceconnector_group, oci_identity_user_group_membership.dd_user_group_membership]
   compartment_id = var.tenancy_ocid
   description    = "[DO NOT REMOVE] Policy to have any connector hub read from monitoring source and write to a target function"
-  name           = var.datadog_metrics_policy
-  statements = ["Allow dynamic-group Default/${var.dynamic_group_name} to read metrics in tenancy",
-    "Allow dynamic-group Default/${var.dynamic_group_name} to use fn-function in tenancy",
-    "Allow dynamic-group Default/${var.dynamic_group_name} to use fn-invocation in tenancy",
-    "Allow group Default/${oci_identity_group.read_policy_group.name} to read all-resources in tenancy"
+  name           = local.datadog_metrics_policy
+  statements = ["Allow dynamic-group Default/${local.dynamic_group_name} to read metrics in tenancy",
+    "Allow dynamic-group Default/${local.dynamic_group_name} to use fn-function in tenancy",
+    "Allow dynamic-group Default/${local.dynamic_group_name} to use fn-invocation in tenancy",
+    "Allow group Default/${oci_identity_group.read_policy_group.name} to read all-resources in tenancy",
+    "Allow group Default/${oci_identity_group.write_user_group.name} to manage repos in tenancy where ANY {request.permission = 'REPOSITORY_READ', request.permission = 'REPOSITORY_UPDATE', request.permission = 'REPOSITORY_CREATE'}"
   ]
   defined_tags  = {}
   freeform_tags = local.freeform_tags
 }
-

--- a/datadog-oci-orm/policy-setup/variables.tf
+++ b/datadog-oci-orm/policy-setup/variables.tf
@@ -6,22 +6,4 @@ variable "tenancy_ocid" {
   description = "OCI tenant OCID, more details can be found at https://docs.cloud.oracle.com/en-us/iaas/Content/API/Concepts/apisigningkey.htm#five"
 }
 
-variable "dynamic_group_name" {
-  type        = string
-  description = "The name of the dynamic group for giving access to service connector"
-  default     = "datadog-metrics-dynamic-group"
-}
-
-variable "user_group_name" {
-  type        = string
-  description = "The name of the group for giving access to user"
-  default     = "DatadogAuthGroup"
-}
-
-variable "datadog_metrics_policy" {
-  type        = string
-  description = "The name of the policy for metrics"
-  default     = "datadog-metrics-policy"
-}
-
 


### PR DESCRIPTION
**what:**

** Policy changes:**
* Create a new user `DatadogAuthWriteUser` which is  used in pushing docker images.
* Change the name of the groups, dynamic group, policy and users so that it doesn't collide with existing stack.
* Remove the option for the name of group name, policy and dynamic group name

**Metric stack:**
* The docker images are only created with the user login created through policy stack.
* If the user is not created through policy stack then no resource will be created.
* A new auth token is created every time on stack run so it is not required to store the credential. It takes at least 60-120 sec for the token to be accepted and used for docker login.

**why:**
* To reduce additional complexity in docker credentials.

**testing:**
* Tested on `datadog84` tenancy. See [here](https://cloud.oracle.com/resourcemanager/jobs/ocid1.ormjob.oc1.eu-frankfurt-1.amaaaaaaehwejaiaavrk7eex4gqpq6pbpvr3l3iqodihqeol7rf7pj62ufza?region=eu-frankfurt-1)