### PR TITLE
ECI-529 Do not do docker login on every stack run

### DIFF
--- a/datadog-oci-orm/metrics-setup/functions.tf
+++ b/datadog-oci-orm/metrics-setup/functions.tf
@@ -12,7 +12,7 @@ resource "oci_functions_application" "metrics_function_app" {
     "TENANCY_OCID"             = var.tenancy_ocid
   }
   defined_tags  = {}
-  display_name  = "${var.resource_name_prefix}-function-app"
+  display_name  = local.oci_function_app
   freeform_tags = local.freeform_tags
   network_security_group_ids = [
   ]
@@ -27,7 +27,7 @@ resource "oci_functions_function" "metrics_function" {
   count      = local.is_service_user_available ? 1 : 0
   #Required
   application_id = oci_functions_application.metrics_function_app[0].id
-  display_name   = "${oci_functions_application.metrics_function_app[0].display_name}-metrics-function"
+  display_name   = local.oci_function_name
   memory_in_mbs  = "256"
 
   #Optional

--- a/datadog-oci-orm/metrics-setup/locals.tf
+++ b/datadog-oci-orm/metrics-setup/locals.tf
@@ -40,3 +40,9 @@ locals {
   docker_image_path     = "${local.oci_docker_repository}/${local.ocir_repo_name}/${local.function_name}:latest"
 }
 
+locals {
+  # OCI function apps
+  oci_function_app  = "${var.resource_name_prefix}-function-app"
+  oci_function_name = "${local.oci_function_app}-metrics-function"
+}
+

--- a/datadog-oci-orm/policy-setup/policy.tf
+++ b/datadog-oci-orm/policy-setup/policy.tf
@@ -117,3 +117,10 @@ resource "oci_identity_policy" "metrics_policy" {
   defined_tags  = {}
   freeform_tags = local.freeform_tags
 }
+
+output "user_output" {
+  value = {
+    user_ocid_to_add_to_datadog_integration = oci_identity_user.read_only_user.id
+    user_name                               = oci_identity_user.read_only_user.name
+  }
+}

--- a/datadog-oci-orm/policy-setup/variables.tf
+++ b/datadog-oci-orm/policy-setup/variables.tf
@@ -8,5 +8,5 @@ variable "tenancy_ocid" {
 
 variable "current_user_ocid" {
   type        = string
-  description = "The OCID of the current user executing the terraform script"
+  description = "The OCID of the current user executing the terraform script. Do not modify."
 }


### PR DESCRIPTION
**what:**

* The docker login re-creates a service user auth token and does a login which takes at least 2-3 minutes.
* This can be skipped if not creating a function image and only refreshing connector hub compartments.
