### PR TITLE
ECI-615 ECI-587 Update stack variables, policies and integration request body

### DIFF
--- a/datadog-integration/locals.tf
+++ b/datadog-integration/locals.tf
@@ -10,4 +10,9 @@ locals {
     for region in data.oci_identity_regions.all_regions.regions : region.name
     if region.key == data.oci_identity_tenancy.tenancy_metadata.home_region_key
   ][0]
+
+  oci_regions = tomap({
+    for region in data.oci_identity_regions.all_regions.regions :
+    region.name => region
+  })
 }

--- a/datadog-integration/main.tf
+++ b/datadog-integration/main.tf
@@ -22,8 +22,6 @@ module "auth" {
   current_user_id  = var.current_user_ocid
   compartment_name = local.compartment_name
   compartment_id   = module.compartment.id
-  forward_metrics  = var.metrics_image_tag != "" ? true : false
-  forward_logs     = var.logs_image_tag != "" ? true : false
 }
 
 module "networking" {
@@ -39,11 +37,10 @@ module "functions" {
   compartment_id    = module.compartment.id
   subnet_id         = module.networking.subnet_id
   tags              = local.tags
-  metrics_image_tag = var.metrics_image_tag
-  logs_image_tag    = var.logs_image_tag
   datadog_site      = var.datadog_site
   home_region       = local.home_region_name
   api_key_secret_id = length(module.kms) > 0 ? module.kms[0].api_key_secret_id : ""
+  region_key        = local.oci_regions[var.region].key
 }
 
 module "integration" {

--- a/datadog-integration/modules/auth/outputs.tf
+++ b/datadog-integration/modules/auth/outputs.tf
@@ -1,5 +1,5 @@
 output "user_id" {
-  value = oci_identity_user.dd_auth_user.id
+  value = oci_identity_user.dd_auth.id
 }
 
 output "private_key" {

--- a/datadog-integration/modules/auth/variables.tf
+++ b/datadog-integration/modules/auth/variables.tf
@@ -29,12 +29,3 @@ variable "current_user_id" {
   type        = string
 }
 
-variable "forward_metrics" {
-  description = "Forward metrics to Datadog"
-  type        = bool
-}
-
-variable "forward_logs" {
-  description = "Forward logs to Datadog"
-  type        = bool
-}

--- a/datadog-integration/modules/functions/locals.tf
+++ b/datadog-integration/modules/functions/locals.tf
@@ -1,21 +1,16 @@
 locals {
-  metrics_image_path = "iad.ocir.io/iduhc9hzgn3o/sva-datadog-functions/metrics-forwarder:${var.metrics_image_tag}"
-  logs_image_path    = "iad.ocir.io/iduhc9hzgn3o/sva-datadog-functions/logs-forwarder:${var.logs_image_tag}"
+  registry_host      = lower("${var.region_key}.ocir.io/iduhc9hzgn3o")
+  metrics_image_path = "${local.registry_host}/oci-datadog-forwarder/metrics:latest"
+  logs_image_path    = "${local.registry_host}/oci-datadog-forwarder/logs:latest"
 
-  config = merge(
-    {
-      "DD_SITE"             = var.datadog_site,
-      "HOME_REGION"         = var.home_region,
-      "API_KEY_SECRET_OCID" = var.api_key_secret_id
-    },
-    length(var.logs_image_tag) > 0 ? {
-      "DATADOG_TAGS"  = "",
-      "EXCLUDE"       = "{}",
-      "DD_BATCH_SIZE" = "1000"
-    } : {},
-    length(var.metrics_image_tag) > 0 ? {
-      "TENANCY_OCID"             = var.tenancy_id,
-      "DETAILED_LOGGING_ENABLED" = "false"
-    } : {}
-  )
+  config = {
+    "DD_SITE"                  = var.datadog_site,
+    "HOME_REGION"              = var.home_region,
+    "API_KEY_SECRET_OCID"      = var.api_key_secret_id
+    "DATADOG_TAGS"             = "",
+    "EXCLUDE"                  = "{}",
+    "DD_BATCH_SIZE"            = "1000",
+    "TENANCY_OCID"             = var.tenancy_id,
+    "DETAILED_LOGGING_ENABLED" = "false"
+  }
 }

--- a/datadog-integration/modules/functions/main.tf
+++ b/datadog-integration/modules/functions/main.tf
@@ -20,7 +20,6 @@ resource "oci_functions_application" "dd_function_app" {
 }
 
 resource "oci_functions_function" "logs_function" {
-  count          = var.logs_image_tag != "" ? 1 : 0
   application_id = oci_functions_application.dd_function_app.id
   display_name   = "dd-logs-forwarder"
   memory_in_mbs  = "1024"
@@ -29,7 +28,6 @@ resource "oci_functions_function" "logs_function" {
 }
 
 resource "oci_functions_function" "metrics_function" {
-  count          = var.metrics_image_tag != "" ? 1 : 0
   application_id = oci_functions_application.dd_function_app.id
   display_name   = "dd-metrics-forwarder"
   memory_in_mbs  = "512"

--- a/datadog-integration/modules/functions/variables.tf
+++ b/datadog-integration/modules/functions/variables.tf
@@ -29,18 +29,6 @@ variable "subnet_id" {
   description = "The OCID of the subnet to be used for the function app"
 }
 
-variable "metrics_image_tag" {
-  type        = string
-  description = "Image tag for forwarding metrics to Datadog"
-  default     = ""
-}
-
-variable "logs_image_tag" {
-  type        = string
-  description = "Image tag for forwarding logs to Datadog"
-  default     = ""
-}
-
 variable "home_region" {
   type        = string
   description = "The name of the home region"
@@ -49,4 +37,9 @@ variable "home_region" {
 variable "api_key_secret_id" {
   type        = string
   description = "The secret ID for the API key"
+}
+
+variable "region_key" {
+  type        = string
+  description = "The 3 letter key of the region used."
 }

--- a/datadog-integration/modules/integration/locals.tf
+++ b/datadog-integration/modules/integration/locals.tf
@@ -1,11 +1,14 @@
 locals {
+
+  config_version = 2
   json_object = {
     data : {
-      type : "CreateTenancyRequest"
+      type : "oci_tenancy",
+      id : var.tenancy_ocid,
       attributes : {
-        tenancy_ocid : "${var.tenancy_ocid}",
         home_region : var.home_region
         user_ocid : var.user_ocid
+        config_version : local.config_version
         auth_credentials : {
           fingerprint : var.public_key_finger_print
           private_key : var.private_key

--- a/datadog-integration/modules/integration/main.tf
+++ b/datadog-integration/modules/integration/main.tf
@@ -11,6 +11,6 @@ terraform {
 resource "restapi_object" "datadog_tenancy_integration" {
   path         = "/api/v2/integration/oci/tenancy"
   data         = local.request_data
-  id_attribute = "data/attributes/tenancy_ocid"
+  id_attribute = "data/id"
   read_path    = "/api/v2/integration/oci/tenancies/{id}"
 }

--- a/datadog-integration/schema.yaml
+++ b/datadog-integration/schema.yaml
@@ -1,7 +1,7 @@
 # Title shown in Application Information tab.
-title: Datadog Log Forwarding Infrastructure
+title: Datadog Forwarding Infrastructure
 # Sub Title shown in Application Information tab.
-description: Setting up infrastructure for sending OCI Logs to Datadog
+description: Setting up infrastructure for sending OCI metrics and logs to Datadog
 schemaVersion: 1.1.0
 version: 1.0
 locale: en
@@ -61,17 +61,3 @@ variables:
     description: The site for Datadog.
     required: true
 
-# Tenancy Options
-  metrics_image_tag:
-    title: Metrics Image Tag
-    type: string
-    description: Image tag for forwarding metrics to Datadog.
-    required: false
-    default: ""
-
-  logs_image_tag:
-    title: Logs Image Tag
-    type: string
-    description: Image tag for forwarding logs to Datadog.
-    required: false
-    default: ""

--- a/datadog-integration/variables.tf
+++ b/datadog-integration/variables.tf
@@ -42,19 +42,3 @@ variable "datadog_site" {
   type        = string
   description = "The Datadog site to send data to (e.g., datadoghq.com, datadoghq.eu)"
 }
-
-#*************************************
-#         Tenancy Options
-#*************************************
-
-variable "metrics_image_tag" {
-  type        = string
-  description = "Image tag for forwarding metrics to Datadog"
-  default     = ""
-}
-
-variable "logs_image_tag" {
-  type        = string
-  description = "Image tag for forwarding logs to Datadog"
-  default     = ""
-}


### PR DESCRIPTION
**what:**

* Policy changes to reduce manage resource permission in the Datadog compartment. Restrict to managing connector hubs and function read/update.
* Change dynamic group policy to have both logs and metrics access. Create logs and metrics forwarding functions by default.
* Remove stack variable for metrics and log tags. Use latest tag from the repository.
* Use region specific key to create image registry path.
* In the create integration, use the up to date request body and pass in the config version 

**why:**
* To align stack update with the integration UI changes.

**testing:**

* The stack ran successfully in the **datadog84** tenancy [here](https://cloud.oracle.com/resourcemanager/jobs/ocid1.ormjob.oc1.iad.amaaaaaaehwejaiaacbwcew22idsb7yodgardqyzzwm3wibtwvhgn6phmraq/resources?region=us-ashburn-1)
* The integration part was separately tested as a module and created tenancy with updated config version