### PR TITLE
reduce connector hub batch size

### DIFF
--- a/datadog-oci-orm/metrics-setup/serviceconnector.tf
+++ b/datadog-oci-orm/metrics-setup/serviceconnector.tf
@@ -58,7 +58,7 @@ resource "oci_sch_service_connector" "metrics_service_connector" {
     kind = "functions"
 
     #Optional
-    batch_size_in_kbs = 5000
+    batch_size_in_kbs = 4096
     batch_time_in_sec = 60
     compartment_id    = var.tenancy_ocid
     function_id       = oci_functions_function.metrics_function[0].id


### PR DESCRIPTION
**what:**
Reduce connector hub batch size from 5000 to 4096.

**why:**
To avoid "payload too large" errors