### PR TITLE
ECI-684: add support for identity domains and advanced inputs

### DIFF
--- a/datadog-integration/data.tf
+++ b/datadog-integration/data.tf
@@ -21,3 +21,7 @@ data "oci_identity_domains_user" "user_in_domain" {
   idcs_endpoint = each.value.url
   user_id       = var.current_user_ocid
 }
+
+data "oci_identity_domain" "domain" {
+  domain_id = local.matching_domain_id
+}

--- a/datadog-integration/locals.tf
+++ b/datadog-integration/locals.tf
@@ -3,14 +3,14 @@ locals {
     ownedby = "datadog"
   }
 
-  compartment_name = "Datadog"
-
   home_region_name = [
     for region in data.oci_identity_region_subscriptions.subscribed_regions.region_subscriptions : region.region_name
     if region.is_home_region
   ][0]
 
   is_current_region_home_region = (var.region == local.home_region_name)
+
+  new_compartment_name = "Datadog"
 }
 
 #Auth Variables
@@ -26,10 +26,13 @@ locals {
     for d in data.oci_identity_domains.all_domains.domains : d
     if d.id == local.matching_domain_id
   ][0]
+  user_email = data.oci_identity_domains_user.user_in_domain[local.matching_domain_id].emails[0].value
 
   domain_display_name = local.matching_domain.display_name
   idcs_endpoint       = local.matching_domain.url
-  email               = data.oci_identity_domains_user.user_in_domain[local.matching_domain_id].emails[0].value
+
+  actual_user_name  = (var.existing_user_id == null || var.existing_user_id == "") ? local.user_name : null
+  actual_group_name = (var.existing_group_id == null || var.existing_group_id == "") ? local.user_group_name : null
 }
 
 # Variables for regions
@@ -48,4 +51,93 @@ locals {
   })
 
   subscribed_regions_set = toset(local.subscribed_regions_list)
+
+  # regions in domain
+  regions_in_domain     = flatten([[data.oci_identity_domain.domain.home_region], [for region in data.oci_identity_domain.domain.replica_regions : region.region]])
+  regions_in_domain_set = toset(local.regions_in_domain)
+
+  # Convert multiline string to list of subnet OCIDs (remove any trailing periods)
+  # First pass: get cleaned lines
+  subnet_ocids_raw = [
+    for line in split("\n", var.subnet_ocids) :
+    trimspace(line) if trimspace(line) != ""
+  ]
+
+  # Second pass: remove trailing periods manually (compatible with Terraform <= 1.5.x)
+  subnet_ocids_list = [
+    for ocid in local.subnet_ocids_raw :
+    length(ocid) > 0 && substr(ocid, length(ocid) - 1, 1) == "." ? substr(ocid, 0, length(ocid) - 1) : ocid
+  ]
+
+  # Create mapping from region key (3-letter code) to full region name
+  region_key_to_name_map = {
+    for region in local.subscribed_regions :
+    region.region_key => region.region_name
+  }
+
+  # Subnet OCID to normalized region name mapping (handles both full names and 3-letter codes)
+  subnet_ocid_to_region_map = {
+    for subnet_ocid in local.subnet_ocids_list :
+    subnet_ocid => (
+      # Safely get the region identifier from OCID (position 3), with bounds checking
+      length(split(".", subnet_ocid)) >= 4 ? (
+        # Convert region identifier to uppercase for lookup (OCIDs contain lowercase, but region_key is uppercase)
+        contains(keys(local.region_key_to_name_map), upper(split(".", subnet_ocid)[3])) ?
+        # If it's a 3-letter code, convert to full name using uppercase lookup
+        local.region_key_to_name_map[upper(split(".", subnet_ocid)[3])] :
+        # Check if it's already a full region name in our subscribed regions
+        contains(local.subscribed_regions_set, split(".", subnet_ocid)[3]) ?
+        split(".", subnet_ocid)[3] :
+        # Otherwise mark as unknown for validation
+        "unknown-region-${split(".", subnet_ocid)[3]}"
+      ) : "invalid-region"
+    )
+  }
+
+  # Get unique normalized region names from provided subnet OCIDs
+  subnet_regions = toset(values(local.subnet_ocid_to_region_map))
+
+  # Region to subnet OCID mapping (takes first subnet OCID per region)
+  region_to_subnet_ocid_map = {
+    for region_name in local.subnet_regions :
+    region_name => [
+      for subnet_ocid, mapped_region in local.subnet_ocid_to_region_map :
+      subnet_ocid if mapped_region == region_name
+    ][0]
+  }
+
+  # Validate that all subnet regions are subscribed regions
+  # Note: subnet_regions contains normalized full region names, so we compare against subscribed regions
+  unsubscribed_subnet_regions = setsubtract(local.subnet_regions, local.subscribed_regions_set)
+
+  # Validation helpers for check blocks
+  invalid_format_ocids = [
+    for ocid in local.subnet_ocids_list : ocid
+    if !can(regex("^ocid1\\.subnet\\.oc[0-9]\\.[a-zA-Z0-9-]+\\.[a-zA-Z0-9]+$", ocid))
+  ]
+
+  duplicate_ocids = [
+    for ocid in local.subnet_ocids_list : ocid
+    if length([for o in local.subnet_ocids_list : o if o == ocid]) > 1
+  ]
+
+  invalid_structure_ocids = [
+    for ocid in local.subnet_ocids_list : ocid
+    if length(split(".", ocid)) != 5
+  ]
+
+  duplicate_regions = [
+    for ocid in local.subnet_ocids_list : ocid
+    if length([
+      for o in local.subnet_ocids_list : o
+      if length(split(".", o)) >= 4 && length(split(".", ocid)) >= 4 && split(".", o)[3] == split(".", ocid)[3]
+    ]) > 1
+  ]
+
+  # Intersection of subscribed regions, regions in domain, and subnet regions (compatible with Terraform <= 1.5.x)
+  # Only create regional stacks for regions that meet all three criteria
+  target_regions_for_stacks = length(local.subnet_ocids_list) > 0 ? toset([
+    for region in local.subscribed_regions_list : region
+    if contains(tolist(local.regions_in_domain_set), region) && contains(tolist(local.subnet_regions), region)
+  ]) : local.subscribed_regions_set
 }

--- a/datadog-integration/main.tf
+++ b/datadog-integration/main.tf
@@ -1,4 +1,177 @@
+# Validate user and group configurations
+resource "null_resource" "user_group_validation" {
+  
+  provisioner "local-exec" {
+    when       = create
+    on_failure = fail
+    command = <<-EOT
+      # Check existing_user_id format if provided
+      if [ "${var.existing_user_id != null ? var.existing_user_id : ""}" != "" ]; then
+        if ! echo "${var.existing_user_id != null ? var.existing_user_id : ""}" | grep -q "^ocid1\\.user\\.oc[0-9]\\."; then
+          echo "ERROR: Invalid existing_user_id format."
+          echo "If provided, existing_user_id must be a valid user OCID starting with: ocid1.user.oc[0-9]."
+          echo "Provided value: '${var.existing_user_id != null ? var.existing_user_id : "null"}'"
+          exit 1
+        fi
+      fi
+      
+      # Check existing_group_id format if provided
+      if [ "${var.existing_group_id != null ? var.existing_group_id : ""}" != "" ]; then
+        if ! echo "${var.existing_group_id != null ? var.existing_group_id : ""}" | grep -q "^ocid1\\.group\\.oc[0-9]\\."; then
+          echo "ERROR: Invalid existing_group_id format."
+          echo "If provided, existing_group_id must be a valid group OCID starting with: ocid1.group.oc[0-9]."
+          echo "Provided value: '${var.existing_group_id != null ? var.existing_group_id : "null"}'"
+          exit 1
+        fi
+      fi
+      
+      # Check that existing_user_id and existing_group_id are both null or both provided
+      USER_IS_NULL="${var.existing_user_id == null ? "true" : "false"}"
+      GROUP_IS_NULL="${var.existing_group_id == null ? "true" : "false"}"
+      
+      if [ "$USER_IS_NULL" != "$GROUP_IS_NULL" ]; then
+        echo "ERROR: existing_user_id and existing_group_id must be either both null or both provided."
+        echo "Provided: existing_user_id = '${var.existing_user_id != null ? var.existing_user_id : "null"}', existing_group_id = '${var.existing_group_id != null ? var.existing_group_id : "null"}'"
+        exit 1
+      fi
+      
+      echo "✅ User and group validation passed"
+    EOT
+  }
+
+  triggers = {
+    existing_user_id = var.existing_user_id != null ? var.existing_user_id : "null"
+    existing_group_id = var.existing_group_id != null ? var.existing_group_id : "null"
+  }
+}
+
+# Validate subnet regions and fail if any unknown regions detected
+resource "null_resource" "subnet_region_validation" {
+  depends_on = [null_resource.user_group_validation]
+  
+  provisioner "local-exec" {
+    when       = create
+    on_failure = fail
+    command = <<-EOT
+      # First check OCID structure validity
+      INVALID_OCIDS="${join(" ", local.invalid_structure_ocids)}"
+      if [ ! -z "$INVALID_OCIDS" ] && [ ${length(local.subnet_ocids_list)} -gt 0 ]; then
+        echo "ERROR: Invalid subnet OCID structure detected:"
+        echo "${join("\n", local.invalid_structure_ocids)}"
+        echo ""
+        echo "All subnet OCIDs must have exactly 5 dot-separated parts (format: ocid1.subnet.oc1.<region>.<unique_id>)."
+        echo "Note: Make sure you are providing subnet OCIDs (ocid1.subnet.oc1...) not VCN OCIDs or other resource types."
+        exit 1
+      fi
+      
+      # Check for duplicate OCIDs
+      DUPLICATE_OCIDS="${join(" ", distinct(local.duplicate_ocids))}"
+      if [ ! -z "$DUPLICATE_OCIDS" ] && [ ${length(local.subnet_ocids_list)} -gt 0 ]; then
+        echo "ERROR: Duplicate subnet OCIDs found:"
+        echo "${join("\n", distinct(local.duplicate_ocids))}"
+        echo ""
+        echo "All subnet OCIDs must be unique."
+        exit 1
+      fi
+      
+      # Check for duplicate regions
+      DUPLICATE_REGIONS="${join(" ", distinct(local.duplicate_regions))}"
+      if [ ! -z "$DUPLICATE_REGIONS" ] && [ ${length(local.subnet_ocids_list)} -gt 0 ]; then
+        echo "ERROR: Multiple subnet OCIDs found in the same region for:"
+        echo "${join("\n", distinct(local.duplicate_regions))}"
+        echo ""
+        echo "Each region can only have one subnet OCID."
+        exit 1
+      fi
+      
+      # Check for unknown regions
+      UNKNOWN_REGIONS="${join(" ", [for region in local.subnet_regions : region if substr(region, 0, 15) == "unknown-region-"])}"
+      if [ ! -z "$UNKNOWN_REGIONS" ]; then
+        echo "ERROR: The following subnet regions are not subscribed in this tenancy: $UNKNOWN_REGIONS"
+        echo ""
+        echo "This usually means the region in the subnet OCID is not subscribed in this tenancy or the region code format is not recognized."
+        echo ""
+        echo "Subscribed regions: ${join(", ", sort(local.subscribed_regions_list))}"
+        echo "Region mapping: ${jsonencode(local.region_key_to_name_map)}"
+        echo ""
+        echo "Please verify your subnet OCIDs are correct and from subscribed regions."
+        exit 1
+      fi
+      echo "✅ All subnet OCIDs are valid and all subnet regions are subscribed"
+    EOT
+  }
+
+  triggers = {
+    subnet_regions = jsonencode(local.subnet_regions)
+    invalid_ocids = jsonencode(local.invalid_structure_ocids)
+    duplicate_ocids = jsonencode(local.duplicate_ocids)
+    duplicate_regions = jsonencode(local.duplicate_regions)
+  }
+}
+
+# Output region intersection logic and validate region consistency
+resource "null_resource" "region_intersection_info" {
+  depends_on = [null_resource.subnet_region_validation]
+  
+  provisioner "local-exec" {
+    when       = create
+    on_failure = fail
+    command = <<-EOT
+      echo "==================== DATADOG REGIONAL STACK DEPLOYMENT INFO ===================="
+      echo "Subscribed regions in tenancy: ${join(", ", sort(tolist(local.subscribed_regions_set)))}"
+      echo "Regions available in identity domain: ${join(", ", sort(tolist(local.regions_in_domain_set)))}"
+      echo "Regions with provided subnet OCIDs: ${length(local.subnet_ocids_list) > 0 ? join(", ", sort(tolist(local.subnet_regions))) : "None (will create subnets in all subscribed regions)"}"
+      echo "Target regions for regional stack deployment: ${join(", ", sort(tolist(local.target_regions_for_stacks)))}"
+      echo "Number of regional stacks to be created: ${length(local.target_regions_for_stacks)}"
+      echo "================================================================================="
+      
+      # Check for region consistency between subscribed regions and domain regions
+      SUBSCRIBED_MINUS_DOMAIN="${join(" ", [for r in local.subscribed_regions_set : r if !contains(tolist(local.regions_in_domain_set), r)])}"
+      DOMAIN_MINUS_SUBSCRIBED="${join(" ", [for r in local.regions_in_domain_set : r if !contains(tolist(local.subscribed_regions_set), r)])}"
+      
+      if [ ! -z "$SUBSCRIBED_MINUS_DOMAIN" ] || [ ! -z "$DOMAIN_MINUS_SUBSCRIBED" ]; then
+        echo ""
+        echo "ERROR: Subscribed regions do not match regions in domain."
+        echo "This indicates a configuration mismatch between the tenancy's subscribed regions and the identity domain's available regions."
+        echo ""
+        echo "Subscribed regions: ${join(", ", sort(tolist(local.subscribed_regions_set)))}"
+        echo "Regions in domain: ${join(", ", sort(tolist(local.regions_in_domain_set)))}"
+        exit 1
+      fi
+      
+      # Check if any regional stacks will be created
+      if [ ${length(local.target_regions_for_stacks)} -eq 0 ]; then
+        echo ""
+        echo "ERROR: No regional stacks will be created!"
+        echo ""
+        echo "This usually happens when:"
+        echo "- Provided subnet OCIDs don't match any subscribed regions"
+        echo "- Provided subnet OCIDs don't match regions available in the identity domain"
+        echo "- All provided subnet regions are invalid or unsupported"
+        echo ""
+        echo "Please check your subnet OCIDs and ensure they belong to regions that are:"
+        echo "1. Subscribed in this tenancy"
+        echo "2. Available in the identity domain"
+        echo "3. Supported by Datadog"
+        exit 1
+      fi
+      
+      echo "✅ Region validation passed - proceeding with deployment"
+    EOT
+  }
+
+  triggers = {
+    region_validation = jsonencode({
+      subscribed_regions = local.subscribed_regions_set
+      domain_regions = local.regions_in_domain_set
+      target_regions = local.target_regions_for_stacks
+    })
+  }
+}
+
 resource "null_resource" "precheck_marker" {
+  depends_on = [null_resource.region_intersection_info]
+  
   provisioner "local-exec" {
     when       = create
     on_failure = fail
@@ -24,7 +197,8 @@ resource "null_resource" "precheck_marker" {
 module "compartment" {
   depends_on            = [null_resource.precheck_marker]
   source                = "./modules/compartment"
-  compartment_name      = local.compartment_name
+  compartment_id        = var.compartment_id
+  new_compartment_name  = local.new_compartment_name
   parent_compartment_id = var.tenancy_ocid
   tags                  = local.tags
 }
@@ -39,21 +213,23 @@ module "kms" {
 }
 
 module "auth" {
-  depends_on             = [null_resource.precheck_marker]
-  source                 = "./modules/auth"
-  count                  = local.is_current_region_home_region ? 1 : 0
-  user_name              = local.user_name
-  tenancy_id             = var.tenancy_ocid
-  tags                   = local.tags
-  current_user_id        = var.current_user_ocid
-  compartment_name       = local.compartment_name
-  compartment_id         = module.compartment.id
-  user_group_name        = local.user_group_name
-  user_group_policy_name = local.user_group_policy_name
-  dg_sch_name            = local.dg_sch_name
-  dg_fn_name             = local.dg_fn_name
-  dg_policy_name         = local.dg_policy_name
-  email                  = local.email
+  depends_on        = [null_resource.precheck_marker]
+  source            = "./modules/auth"
+  count             = local.is_current_region_home_region ? 1 : 0
+  user_name         = local.actual_user_name
+  user_email        = local.user_email
+  tenancy_id        = var.tenancy_ocid
+  tags              = local.tags
+  current_user_id   = var.current_user_ocid
+  compartment_id    = module.compartment.id
+  idcs_endpoint     = local.idcs_endpoint
+  existing_user_id  = var.existing_user_id
+  existing_group_id = var.existing_group_id
+  user_group_name   = local.actual_group_name
+  user_policy_name  = local.user_group_policy_name
+  dg_sch_name       = local.dg_sch_name
+  dg_fn_name        = local.dg_fn_name
+  dg_policy_name    = local.dg_policy_name
 }
 
 module "key" {
@@ -63,11 +239,13 @@ module "key" {
   tenancy_ocid     = var.tenancy_ocid
   compartment_ocid = module.compartment.id
   region           = var.region
-  depends_on       = [module.auth]
+  idcs_endpoint    = local.idcs_endpoint
+  tags             = local.tags
+  depends_on       = [null_resource.precheck_marker, module.auth]
 }
 
 module "integration" {
-  depends_on = [module.kms]
+  depends_on = [null_resource.precheck_marker, module.auth, module.key, module.kms]
   source     = "./modules/integration"
   providers = {
     restapi = restapi
@@ -80,6 +258,8 @@ module "integration" {
   tenancy_ocid                    = var.tenancy_ocid
   private_key                     = module.key[0].private_key
   user_ocid                       = module.auth[0].user_id
-  subscribed_regions              = local.supported_regions_list
+  subscribed_regions              = tolist(local.target_regions_for_stacks)
   datadog_resource_compartment_id = module.compartment.id
 }
+
+

--- a/datadog-integration/modules/auth/data.tf
+++ b/datadog-integration/modules/auth/data.tf
@@ -1,0 +1,18 @@
+data "oci_identity_tenancy" "tenancy" {
+  tenancy_id = var.tenancy_id
+}
+
+# Get existing group by OCID (only when group OCID is provided and not empty)
+data "oci_identity_domains_groups" "existing_group" {
+  count         = var.existing_group_id != null && var.existing_group_id != "" ? 1 : 0
+  idcs_endpoint = var.idcs_endpoint
+  group_filter  = "ocid eq \"${var.existing_group_id}\""
+}
+
+# Get user by OCID with group memberships (when user OCID is provided and not empty)
+data "oci_identity_domains_users" "existing_user_with_groups" {
+  count        = var.existing_user_id != null && var.existing_user_id != "" ? 1 : 0
+  idcs_endpoint = var.idcs_endpoint
+  user_filter  = "ocid eq \"${var.existing_user_id}\""
+  attributes   = "groups"
+}

--- a/datadog-integration/modules/auth/locals.tf
+++ b/datadog-integration/modules/auth/locals.tf
@@ -1,0 +1,3 @@
+locals {
+  email = var.user_email
+}

--- a/datadog-integration/modules/auth/main.tf
+++ b/datadog-integration/modules/auth/main.tf
@@ -3,76 +3,211 @@ terraform {
   required_providers {
     oci = {
       source  = "oracle/oci"
-      version = "5.46.0"
+      version = ">=7.1.0"
     }
   }
 }
 
-resource "oci_identity_user" "dd_auth" {
-  # Required
-  compartment_id = var.tenancy_id
-  description    = "[DO NOT REMOVE] Read only user created for fetching resources metadata which is used by Datadog Integrations"
-  name           = var.user_name
-  email          = var.email
-  freeform_tags  = var.tags
+# Stage 1: Validate that both user and group variables are either both null/empty OR both provided
+resource "null_resource" "user_group_variable_validation" {
+  
+  provisioner "local-exec" {
+    when       = create
+    on_failure = fail
+    command = <<-EOT
+      # Check variable consistency
+      USER_PROVIDED="${var.existing_user_id != null && var.existing_user_id != "" ? "true" : "false"}"
+      GROUP_PROVIDED="${var.existing_group_id != null && var.existing_group_id != "" ? "true" : "false"}"
+      
+      if [ "$USER_PROVIDED" != "$GROUP_PROVIDED" ]; then
+        echo "ERROR: Both existing_user_id and existing_group_id must be provided together, or both must be null/empty."
+        echo "Current state:"
+        echo "  existing_user_id: ${var.existing_user_id != null ? var.existing_user_id : "null/empty"}"
+        echo "  existing_group_id: ${var.existing_group_id != null ? var.existing_group_id : "null/empty"}"
+        exit 1
+      fi
+      
+      if [ "$USER_PROVIDED" = "false" ] && [ "$GROUP_PROVIDED" = "false" ]; then
+        echo "✅ No existing user/group provided - will create new ones"
+      else
+        echo "✅ Both existing user and group provided - will validate them in next stage"
+      fi
+    EOT
+  }
 }
 
-resource "oci_identity_group" "dd_auth" {
-  # Required
-  compartment_id = var.tenancy_id
-  description    = "[DO NOT REMOVE] Group for adding permissions to Datadog user"
-  name           = var.user_group_name
-  freeform_tags  = var.tags
+# Stage 2: Validate data sources only when both variables are provided
+resource "null_resource" "existing_user_group_validation" {
+  count = var.existing_user_id != null && var.existing_user_id != "" && var.existing_group_id != null && var.existing_group_id != "" ? 1 : 0
+  
+  depends_on = [null_resource.user_group_variable_validation]
+  
+  provisioner "local-exec" {
+    when       = create
+    on_failure = fail
+    command = <<-EOT
+      # First check if the data sources returned any results
+      USER_DATA_COUNT=${length(data.oci_identity_domains_users.existing_user_with_groups)}
+      GROUP_DATA_COUNT=${length(data.oci_identity_domains_groups.existing_group)}
+      
+      if [ $USER_DATA_COUNT -eq 0 ]; then
+        echo "ERROR: No user data found for OCID '${var.existing_user_id}'"
+        echo "This could mean:"
+        echo "  - The OCID is invalid or malformed"
+        echo "  - The user does not exist in this Identity Domain"
+        echo "  - The OCID belongs to a different Identity Domain"
+        echo "  - You don't have permission to read this user"
+        exit 1
+      fi
+      
+      if [ $GROUP_DATA_COUNT -eq 0 ]; then
+        echo "ERROR: No group data found for OCID '${var.existing_group_id}'"
+        echo "This could mean:"
+        echo "  - The OCID is invalid or malformed"
+        echo "  - The group does not exist in this Identity Domain"
+        echo "  - The OCID belongs to a different Identity Domain"
+        echo "  - You don't have permission to read this group"
+        exit 1
+      fi
+      
+      # Now check if the SCIM filter found actual users and groups
+      USER_COUNT=${length(data.oci_identity_domains_users.existing_user_with_groups[0].users)}
+      GROUP_COUNT=${length(data.oci_identity_domains_groups.existing_group[0].groups)}
+      
+      if [ $USER_COUNT -eq 0 ]; then
+        echo "ERROR: No user found with OCID '${var.existing_user_id}'"
+        echo "This could mean:"
+        echo "  - The OCID is invalid or malformed"
+        echo "  - The user does not exist in this Identity Domain"
+        echo "  - The OCID belongs to a different Identity Domain"
+        echo "  - You don't have permission to read this user"
+        exit 1
+      fi
+      
+      if [ $GROUP_COUNT -eq 0 ]; then
+        echo "ERROR: No group found with OCID '${var.existing_group_id}'"
+        echo "This could mean:"
+        echo "  - The OCID is invalid or malformed"
+        echo "  - The group does not exist in this Identity Domain"
+        echo "  - The OCID belongs to a different Identity Domain"
+        echo "  - You don't have permission to read this group"
+        exit 1
+      fi
+      
+      # Only check group membership if both user and group exist
+      # The user's groups are in data.oci_identity_domains_users.existing_user_with_groups[0].users[0].groups[*].ocid
+      USER_GROUPS_JSON='${jsonencode(length(data.oci_identity_domains_users.existing_user_with_groups[0].users) > 0 ? data.oci_identity_domains_users.existing_user_with_groups[0].users[0].groups : [])}'
+      USER_GROUPS=$(echo "$USER_GROUPS_JSON" | grep -o '"ocid":"[^"]*"' | cut -d'"' -f4 || echo "")
+      TARGET_GROUP_OCID="${var.existing_group_id}"
+      
+      if echo "$USER_GROUPS" | grep -q "$TARGET_GROUP_OCID"; then
+        echo "✅ User '${var.existing_user_id}' is a member of group '${var.existing_group_id}'"
+      else
+        echo "ERROR: User '${var.existing_user_id}' is not a member of group '${var.existing_group_id}'"
+        echo "User's current group memberships:"
+        echo "$USER_GROUPS"
+        exit 1
+      fi
+    EOT
+  }
 }
 
-resource "oci_identity_user_group_membership" "dd_user_group_membership" {
-  # Required
-  group_id = oci_identity_group.dd_auth.id
-  user_id  = oci_identity_user.dd_auth.id
+resource "oci_identity_domains_user" "dd_auth" {
+  depends_on    = [null_resource.user_group_variable_validation]
+  count         = var.existing_user_id == null || var.existing_user_id == "" ? 1 : 0
+  idcs_endpoint = var.idcs_endpoint
+  schemas       = ["urn:ietf:params:scim:schemas:core:2.0:User", "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User"]
+  user_name     = var.user_name
+  emails {
+    primary = true
+    value   = local.email
+    type    = "work"
+  }
+  name {
+    family_name = var.user_name
+    given_name  = var.user_name
+  }
+  display_name = var.user_name
+
+  urnietfparamsscimschemasoracleidcsextension_oci_tags {
+    dynamic "freeform_tags" {
+      for_each = var.tags
+      content {
+        key   = freeform_tags.key
+        value = freeform_tags.value
+      }
+    }
+  }
+}
+
+resource "oci_identity_domains_group" "dd_auth" {
+  depends_on    = [null_resource.user_group_variable_validation]
+  count         = var.existing_group_id == null || var.existing_group_id == "" ? 1 : 0
+  idcs_endpoint = var.idcs_endpoint
+  schemas       = ["urn:ietf:params:scim:schemas:core:2.0:Group"]
+  display_name  = var.user_group_name
+
+  # Add user to group
+  members {
+    value = var.existing_user_id != null && var.existing_user_id != "" ? var.existing_user_id : oci_identity_domains_user.dd_auth[0].id
+    type  = "User"
+  }
+
+  urnietfparamsscimschemasoracleidcsextension_oci_tags {
+    dynamic "freeform_tags" {
+      for_each = var.tags
+      content {
+        key   = freeform_tags.key
+        value = freeform_tags.value
+      }
+    }
+  }
 }
 
 resource "oci_identity_policy" "dd_auth" {
+  depends_on     = [null_resource.user_group_variable_validation, oci_identity_domains_group.dd_auth]
   compartment_id = var.tenancy_id
   description    = "[DO NOT REMOVE] Policies required by Datadog User"
-  name           = var.user_group_policy_name
+  name           = var.user_policy_name
   statements = [
-    "Define tenancy usage-report as ocid1.tenancy.oc1..aaaaaaaaned4fkpkisbwjlr56u7cj63lf3wffbilvqknstgtvzub",
-    "Allow group ${oci_identity_group.dd_auth.name} to read all-resources in tenancy",
-    "Allow group ${oci_identity_group.dd_auth.name} to manage serviceconnectors in compartment ${var.compartment_name}",
-    "Allow group ${oci_identity_group.dd_auth.name} to manage functions-family in compartment ${var.compartment_name} where ANY {request.permission = 'FN_FUNCTION_UPDATE', request.permission = 'FN_FUNCTION_LIST', request.permission = 'FN_APP_LIST'}",
-    "Endorse group ${oci_identity_group.dd_auth.name} to read objects in tenancy usage-report"
+    "Define tenancy usage-report as ocid1.tenancy.oc1..aaaaaaaaned4fkpkisbwjlr56u7cj63lf3wffbilvqknstgtvzub7vhqkggq",
+    "Allow group id ${var.existing_group_id != null && var.existing_group_id != "" ? var.existing_group_id : oci_identity_domains_group.dd_auth[0].ocid} to read all-resources in tenancy",
+    "Allow group id ${var.existing_group_id != null && var.existing_group_id != "" ? var.existing_group_id : oci_identity_domains_group.dd_auth[0].ocid} to manage serviceconnectors in compartment id ${var.compartment_id}",
+    "Allow group id ${var.existing_group_id != null && var.existing_group_id != "" ? var.existing_group_id : oci_identity_domains_group.dd_auth[0].ocid} to manage functions-family in compartment id ${var.compartment_id} where ANY {request.permission = 'FN_FUNCTION_UPDATE', request.permission = 'FN_FUNCTION_LIST', request.permission = 'FN_APP_LIST'}",
+    "Endorse group id ${var.existing_group_id != null && var.existing_group_id != "" ? var.existing_group_id : oci_identity_domains_group.dd_auth[0].ocid} to read objects in tenancy usage-report"
   ]
   freeform_tags = var.tags
 }
 
-resource "oci_identity_dynamic_group" "service_connector" {
-  # Required
-  compartment_id = var.tenancy_id
-  description    = "[DO NOT REMOVE] Dynamic group for forwarding by service connector"
-  matching_rule  = "All {resource.type = 'serviceconnector', resource.compartment.id = '${var.compartment_id}'}"
-  name           = var.dg_sch_name
-  freeform_tags  = var.tags
+resource "oci_identity_domains_dynamic_resource_group" "service_connector" {
+  depends_on    = [null_resource.user_group_variable_validation]
+  idcs_endpoint = var.idcs_endpoint
+  schemas       = ["urn:ietf:params:scim:schemas:oracle:idcs:DynamicResourceGroup"]
+  display_name  = var.dg_sch_name
+  description   = "[DO NOT REMOVE] Dynamic group for forwarding by service connector"
+  matching_rule = "All {resource.type = 'serviceconnector', resource.compartment.id = '${var.compartment_id}'}"
 }
 
-resource "oci_identity_dynamic_group" "forwarding_function" {
-  # Required
-  compartment_id = var.tenancy_id
-  description    = "[DO NOT REMOVE] Dynamic group for forwarding functions"
-  matching_rule  = "All {resource.type = 'fnfunc', resource.compartment.id = '${var.compartment_id}'}"
-  name           = var.dg_fn_name
-  freeform_tags  = var.tags
+resource "oci_identity_domains_dynamic_resource_group" "forwarding_function" {
+  depends_on    = [null_resource.user_group_variable_validation]
+  idcs_endpoint = var.idcs_endpoint
+  schemas       = ["urn:ietf:params:scim:schemas:oracle:idcs:DynamicResourceGroup"]
+  display_name  = var.dg_fn_name
+  description   = "[DO NOT REMOVE] Dynamic group for forwarding functions"
+  matching_rule = "All {resource.type = 'fnfunc', resource.compartment.id = '${var.compartment_id}'}"
 }
 
 resource "oci_identity_policy" "dynamic_group" {
-  depends_on     = [oci_identity_dynamic_group.service_connector]
+  depends_on     = [null_resource.user_group_variable_validation, oci_identity_domains_dynamic_resource_group.service_connector]
   compartment_id = var.tenancy_id
   description    = "[DO NOT REMOVE] Policy to have any connector hub read from eligible sources and write to a target function"
   name           = var.dg_policy_name
-  statements = ["Allow dynamic-group Default/${var.dg_sch_name} to read log-content in tenancy",
-    "Allow dynamic-group Default/${var.dg_sch_name} to read metrics in tenancy",
-    "Allow dynamic-group Default/${var.dg_sch_name} to use fn-function in compartment ${var.compartment_name}",
-    "Allow dynamic-group Default/${var.dg_sch_name} to use fn-invocation in compartment ${var.compartment_name}",
-    "Allow dynamic-group Default/${var.dg_fn_name} to read secret-bundles in compartment ${var.compartment_name}"
+  statements = [
+    "Allow dynamic-group id ${oci_identity_domains_dynamic_resource_group.service_connector.ocid} to read log-content in tenancy",
+    "Allow dynamic-group id ${oci_identity_domains_dynamic_resource_group.service_connector.ocid} to read metrics in tenancy",
+    "Allow dynamic-group id ${oci_identity_domains_dynamic_resource_group.service_connector.ocid} to use fn-function in compartment id ${var.compartment_id}",
+    "Allow dynamic-group id ${oci_identity_domains_dynamic_resource_group.service_connector.ocid} to use fn-invocation in compartment id ${var.compartment_id}",
+    "Allow dynamic-group id ${oci_identity_domains_dynamic_resource_group.forwarding_function.ocid} to read secret-bundles in compartment id ${var.compartment_id}"
   ]
   freeform_tags = var.tags
 }

--- a/datadog-integration/modules/auth/outputs.tf
+++ b/datadog-integration/modules/auth/outputs.tf
@@ -1,7 +1,17 @@
 output "user_id" {
-  value = oci_identity_user.dd_auth.id
+  value = var.existing_user_id != null ? var.existing_user_id : oci_identity_domains_user.dd_auth[0].ocid
 }
 
 output "group_id" {
-  value = oci_identity_group.dd_auth.id
+  value = var.existing_group_id != null ? var.existing_group_id : oci_identity_domains_group.dd_auth[0].ocid
+}
+
+output "service_connector_dynamic_group_id" {
+  description = "The OCID of the service connector dynamic group"
+  value       = oci_identity_domains_dynamic_resource_group.service_connector.id
+}
+
+output "forwarding_function_dynamic_group_id" {
+  description = "The OCID of the forwarding function dynamic group"
+  value       = oci_identity_domains_dynamic_resource_group.forwarding_function.id
 }

--- a/datadog-integration/modules/auth/variables.tf
+++ b/datadog-integration/modules/auth/variables.tf
@@ -1,6 +1,13 @@
 variable "user_name" {
-  description = "The name of the user"
+  description = "The name of the user to create. Only used if existing_user_id is not provided."
   type        = string
+  default     = null
+}
+
+variable "user_email" {
+  description = "The email address of the current user"
+  type        = string
+  default     = ""
 }
 
 variable "tags" {
@@ -14,11 +21,6 @@ variable "tenancy_id" {
   description = "OCI tenant OCID, more details can be found at https://docs.cloud.oracle.com/en-us/iaas/Content/API/Concepts/apisigningkey.htm#five"
 }
 
-variable "compartment_name" {
-  description = "The name of the compartment"
-  type        = string
-}
-
 variable "compartment_id" {
   type        = string
   description = "The OCID of the compartment for the dynamic group of all service connector resources"
@@ -29,33 +31,46 @@ variable "current_user_id" {
   type        = string
 }
 
-variable "user_group_name" {
-  description = "Name of the user group to be created or used."
+variable "idcs_endpoint" {
+  description = "The IDCS endpoint URL for the domain"
   type        = string
 }
 
-variable "user_group_policy_name" {
-  description = "Name of the policy to be created or used for user group."
+variable "existing_user_id" {
+  description = "The OCID of an existing user to use. If provided, user_name will be ignored."
+  type        = string
+  default     = null
+}
+
+variable "existing_group_id" {
+  description = "The OCID of an existing group to use. If provided, a new group will not be created."
+  type        = string
+  default     = null
+}
+
+variable "user_group_name" {
+  description = "The name of the user group to create"
+  type        = string
+  default     = null
+}
+
+variable "user_policy_name" {
+  description = "The name of the user policy to create"
   type        = string
 }
 
 variable "dg_sch_name" {
-  description = "Name of the dynamic group for connector hubs."
+  description = "The name of the dynamic group for service connector hubs"
   type        = string
 }
 
 variable "dg_fn_name" {
-  description = "Name of the dynamic group for functions."
+  description = "The name of the dynamic group for functions"
   type        = string
 }
 
 variable "dg_policy_name" {
-  description = "Name of the policy for dynamic groups."
-  type        = string
-}
-
-variable "email" {
-  description = "The email address for the user."
+  description = "The name of the dynamic group policy"
   type        = string
 }
 

--- a/datadog-integration/modules/compartment/locals.tf
+++ b/datadog-integration/modules/compartment/locals.tf
@@ -1,0 +1,6 @@
+
+# Local value to provide the correct compartment ID
+locals {
+  compartment_id   = var.compartment_id != null ? var.compartment_id : oci_identity_compartment.new[0].id
+  compartment_name = var.compartment_id != null ? data.oci_identity_compartment.existing[0].name : oci_identity_compartment.new[0].name
+}

--- a/datadog-integration/modules/compartment/main.tf
+++ b/datadog-integration/modules/compartment/main.tf
@@ -3,13 +3,21 @@ terraform {
   required_providers {
     oci = {
       source  = "oracle/oci"
-      version = "5.46.0"
+      version = ">=7.1.0"
     }
   }
 }
 
-resource "oci_identity_compartment" "this" {
-  name           = var.compartment_name
+# Conditional compartment logic
+# Use existing compartment if provided, otherwise create new one
+data "oci_identity_compartment" "existing" {
+  count = var.compartment_id != null ? 1 : 0
+  id    = var.compartment_id
+}
+
+resource "oci_identity_compartment" "new" {
+  count          = var.compartment_id == null ? 1 : 0
+  name           = var.new_compartment_name
   description    = "Compartment for Datadog generated resources"
   compartment_id = var.parent_compartment_id
   freeform_tags  = var.tags

--- a/datadog-integration/modules/compartment/outputs.tf
+++ b/datadog-integration/modules/compartment/outputs.tf
@@ -1,3 +1,3 @@
 output "id" {
-  value = oci_identity_compartment.this.id
+  value = local.compartment_id
 }

--- a/datadog-integration/modules/compartment/variables.tf
+++ b/datadog-integration/modules/compartment/variables.tf
@@ -1,6 +1,7 @@
-variable "compartment_name" {
-  description = "The name of the compartment"
+variable "compartment_id" {
+  description = "The id of the compartment"
   type        = string
+  default     = null
 }
 
 variable "parent_compartment_id" {
@@ -12,4 +13,10 @@ variable "tags" {
   description = "A map of tags to assign to the compartment"
   type        = map(string)
   default     = {}
+}
+
+variable "new_compartment_name" {
+  description = "The name of the new compartment to create, if no compartment_id is provided"
+  type        = string
+  default     = "Datadog"
 }

--- a/datadog-integration/modules/integration/main.tf
+++ b/datadog-integration/modules/integration/main.tf
@@ -5,6 +5,10 @@ terraform {
       source  = "Mastercard/restapi"
       version = "1.20.0"
     }
+    external = {
+      source  = "hashicorp/external"
+      version = ">= 2.0.0"
+    }
   }
 }
 

--- a/datadog-integration/modules/key/data.tf
+++ b/datadog-integration/modules/key/data.tf
@@ -2,14 +2,6 @@ data "oci_identity_tenancy" "tenancy" {
   tenancy_id = var.tenancy_ocid
 }
 
-data "oci_identity_domains" "domains" {
-  compartment_id = var.tenancy_ocid
-}
-
-data "oci_identity_domain" "selected_domain" {
-  domain_id = [for domain in data.oci_identity_domains.domains.domains : domain.id if domain.display_name == var.domain_name][0]
-}
-
 data "local_sensitive_file" "private_key" {
   filename   = "/tmp/sshkey"
   depends_on = [terraform_data.manage_api_key]

--- a/datadog-integration/modules/key/locals.tf
+++ b/datadog-integration/modules/key/locals.tf
@@ -1,6 +1,6 @@
 locals {
   user_id = var.existing_user_id
-  # Always get the IDCS endpoint from the selected domain
-  idcs_endpoint  = data.oci_identity_domain.selected_domain.url
+  # Use the IDCS endpoint passed from parent module
+  idcs_endpoint  = var.idcs_endpoint
   endpoint_param = "--endpoint ${local.idcs_endpoint}"
 }

--- a/datadog-integration/modules/key/main.tf
+++ b/datadog-integration/modules/key/main.tf
@@ -3,10 +3,11 @@ terraform {
   required_providers {
     oci = {
       source  = "oracle/oci"
-      version = "5.46.0"
+      version = ">=7.1.0"
     }
     local = {
-      source = "hashicorp/local"
+      source  = "hashicorp/local"
+      version = ">= 2.0.0"
     }
   }
 }

--- a/datadog-integration/modules/key/variables.tf
+++ b/datadog-integration/modules/key/variables.tf
@@ -18,14 +18,19 @@ variable "tenancy_ocid" {
 }
 
 variable "existing_user_id" {
-  description = "The OCID of the existing user to create the API key for"
+  description = "The OCID of the user for whom to create the API key"
   type        = string
 }
 
-variable "domain_name" {
-  description = "The name of the identity domain. If not provided, the default domain will be used."
+variable "idcs_endpoint" {
+  description = "The IDCS endpoint URL for the domain"
   type        = string
-  default     = "Default"
+}
+
+variable "tags" {
+  description = "A map of tags to assign to the resource"
+  type        = map(string)
+  default     = {}
 }
 
 variable "auth_method" {

--- a/datadog-integration/modules/kms/main.tf
+++ b/datadog-integration/modules/kms/main.tf
@@ -3,10 +3,11 @@ terraform {
   required_providers {
     oci = {
       source  = "oracle/oci"
-      version = "5.46.0"
+      version = ">=7.1.0"
     }
   }
 }
+
 
 resource "oci_kms_vault" "datadog_vault" {
   compartment_id = var.compartment_id
@@ -37,3 +38,4 @@ resource "oci_vault_secret" "api_key" {
   }
   freeform_tags = var.tags
 }
+

--- a/datadog-integration/modules/regional-stacks/data.tf
+++ b/datadog-integration/modules/regional-stacks/data.tf
@@ -9,8 +9,8 @@ data "http" "token_metrics" {
 locals {
   logs_token        = jsondecode(data.http.token_logs.response_body).token
   metrics_token     = jsondecode(data.http.token_metrics.response_body).token
-  image_sha_logs    = data.http.logs_image.response_headers.Docker-Content-Digest
-  image_sha_metrics = data.http.metrics_image.response_headers.Docker-Content-Digest
+  image_sha_logs    = contains(keys(data.http.logs_image.response_headers), "Docker-Content-Digest") ? data.http.logs_image.response_headers["Docker-Content-Digest"] : (contains(keys(data.http.logs_image.response_headers), "docker-content-digest") ? data.http.logs_image.response_headers["docker-content-digest"] : "")
+  image_sha_metrics = contains(keys(data.http.metrics_image.response_headers), "Docker-Content-Digest") ? data.http.metrics_image.response_headers["Docker-Content-Digest"] : (contains(keys(data.http.metrics_image.response_headers), "docker-content-digest") ? data.http.metrics_image.response_headers["docker-content-digest"] : "")
 }
 
 
@@ -28,4 +28,10 @@ data "http" "metrics_image" {
     Accept        = "application/vnd.oci.image.index.v1+json"
     Authorization = "Bearer ${local.metrics_token}"
   }
+}
+
+# Validate that the provided subnet OCID exists and is accessible
+data "oci_core_subnet" "provided_subnet" {
+  count     = var.subnet_ocid != "" ? 1 : 0
+  subnet_id = var.subnet_ocid
 }

--- a/datadog-integration/modules/regional-stacks/locals.tf
+++ b/datadog-integration/modules/regional-stacks/locals.tf
@@ -27,4 +27,17 @@ locals {
   nat_gateway     = "${local.vcn_name}-natgateway"
   service_gateway = "${local.vcn_name}-servicegateway"
   subnet          = "${local.vcn_name}-private-subnet"
+
+  # Subnet region validation when OCID is provided (handles both 3-letter codes and full names)
+  subnet_region_from_ocid = var.subnet_ocid != "" ? split(".", var.subnet_ocid)[3] : ""
+  
+  # Check if the region from OCID matches current region (either by full name or region key)
+  # Convert extracted region to uppercase for comparison since region_key is uppercase
+  subnet_region_matches = var.subnet_ocid == "" || (
+    local.subnet_region_from_ocid == var.region || 
+    upper(local.subnet_region_from_ocid) == var.region_key
+  )
+  
+  # Simple subnet selection logic: use provided OCID or create new
+  subnet_id = var.subnet_ocid != "" ? var.subnet_ocid : module.vcn[0].subnet_id[local.subnet]
 }

--- a/datadog-integration/modules/regional-stacks/outputs.tf
+++ b/datadog-integration/modules/regional-stacks/outputs.tf
@@ -1,6 +1,6 @@
 output "output_ids" {
   value = {
-    subnet       = module.vcn.subnet_id[local.subnet]
+    subnet       = local.subnet_id
     function_app = oci_functions_application.dd_function_app.id
   }
 }

--- a/datadog-integration/modules/regional-stacks/variables.tf
+++ b/datadog-integration/modules/regional-stacks/variables.tf
@@ -40,3 +40,14 @@ variable "region_key" {
   type        = string
   description = "The 3 letter key of the region used."
 }
+
+variable "subnet_ocid" {
+  type        = string
+  description = "Optional OCID of an existing subnet to use. If not provided, a new subnet will be created."
+  default     = ""
+  
+  validation {
+    condition = var.subnet_ocid == "" || can(regex("^ocid1\\.subnet\\.oc[0-9]\\.", var.subnet_ocid))
+    error_message = "If provided, subnet_ocid must be a valid subnet OCID starting with: ocid1.subnet.oc[0-9]."
+  }
+}

--- a/datadog-integration/pre_check.py
+++ b/datadog-integration/pre_check.py
@@ -62,7 +62,7 @@ def validate_home_region_support(home_region, supported_regions):
 
 def validate_default_domain(domain_name):
     if domain_name != DEFAULT_DOMAIN_NAME:
-        return "Current user is not in the default domain."
+        print("Current user is not in the Default domain: ",domain_name)
     return OK_STATUS
 
 def validate_pre_existing_resources(params, domain_endpoint):

--- a/datadog-integration/providers.tf
+++ b/datadog-integration/providers.tf
@@ -3,17 +3,19 @@ terraform {
   required_providers {
     oci = {
       source  = "oracle/oci"
-      version = "5.46.0"
-    }
-    tls = {
-      source = "hashicorp/tls"
-    }
-    http = {
-      source = "hashicorp/http"
+      version = ">=7.1.0"
     }
     restapi = {
       source  = "Mastercard/restapi"
       version = "1.20.0"
+    }
+    external = {
+      source  = "hashicorp/external"
+      version = ">= 2.0"
+    }
+    null = {
+      source  = "hashicorp/null"
+      version = ">= 3.0"
     }
   }
 }

--- a/datadog-integration/regional_stack.tf
+++ b/datadog-integration/regional_stack.tf
@@ -1,8 +1,9 @@
+
 resource "terraform_data" "regional_stack_zip" {
   depends_on = [null_resource.precheck_marker]
   provisioner "local-exec" {
     working_dir = "${path.module}/modules/regional-stacks"
-    command     = "rm dd_regional_stack.zip;zip -r dd_regional_stack.zip ./*.tf"
+    command     = "rm -f dd_regional_stack.zip && zip -r dd_regional_stack.zip ./*.tf"
   }
   triggers_replace = {
     "key" = timestamp()
@@ -18,11 +19,12 @@ resource "terraform_data" "stack_digest" {
   }
 }
 
+
 # Using a null resource because we want this to be applied on every execution.
 resource "null_resource" "regional_stacks_create_apply" {
-  depends_on = [terraform_data.regional_stack_zip, terraform_data.stack_digest]
-  # Not using local.supported_region_set here because that is determined during apply time and terraform needs to be aware of exact length during plan stage
-  for_each = local.subscribed_regions_set
+  depends_on = [null_resource.precheck_marker, null_resource.region_intersection_info, terraform_data.regional_stack_zip, terraform_data.stack_digest, module.compartment, module.auth, module.kms]
+  # Using intersection of subscribed regions, domain regions, and subnet regions
+  for_each = local.target_regions_for_stacks
   provisioner "local-exec" {
     working_dir = path.module
     command     = <<EOT
@@ -57,7 +59,8 @@ resource "null_resource" "regional_stacks_create_apply" {
       STACK_ID=$(oci resource-manager stack create --compartment-id ${module.compartment.id} --display-name $STACK_NAME \
       --config-source ${path.module}/modules/regional-stacks/dd_regional_stack.zip  --variables '{"tenancy_ocid": "${var.tenancy_ocid}", "region": "${each.key}", \
       "compartment_ocid": "${module.compartment.id}", "datadog_site": "${var.datadog_site}", "api_key_secret_id": "${module.kms[0].api_key_secret_id}", \
-      "home_region": "${local.home_region_name}", "region_key": "${local.subscribed_regions_map[each.key].region_key}"}' \
+      "home_region": "${local.home_region_name}", "region_key": "${local.subscribed_regions_map[each.key].region_key}", \
+      "subnet_ocid": "${lookup(local.region_to_subnet_ocid_map, each.key, "")}"}' \
       --query "data.id" --raw-output --region ${each.key})
       echo "Created Stack ID: $STACK_ID in region ${each.key}"
     else
@@ -82,8 +85,8 @@ resource "null_resource" "regional_stacks_create_apply" {
 # Using terraform_data only for destroy because other resource data or local variables cannot be referenced in destroy block. terraform_data allows that to refer from the self reference which is not 
 # present in null_resource. This is not used during create because terraform_data is destroyed on trigger.
 resource "terraform_data" "regional_stacks_destroy" {
-  depends_on = [terraform_data.regional_stack_zip, terraform_data.stack_digest]
-  for_each   = local.subscribed_regions_set
+  depends_on = [null_resource.precheck_marker, terraform_data.regional_stack_zip, terraform_data.stack_digest]
+  for_each   = local.target_regions_for_stacks
   input = {
     compartment     = module.compartment.id
     stack_digest_id = terraform_data.stack_digest.id

--- a/datadog-integration/schema.yaml
+++ b/datadog-integration/schema.yaml
@@ -18,23 +18,69 @@ variableGroups:
       - ${datadog_app_key}
       - ${datadog_api_key}
       - ${datadog_site}
+  - title: "(Optional) Choose Specific Subnet(s)"
+    variables:
+      - ${choose_subnet}
+      - ${subnet_ocids}
+  - title: "(Optional) Advanced Configuration"
+    variables:
+      - ${show_advanced_options}
+      - ${compartment_id}
+      - ${existing_group_id}
+      - ${existing_user_id}
 
 variables:
+  choose_subnet:
+    title: Choose Specific Subnet(s)
+    type: boolean
+    description: |
+      Use an existing subnet for the Datadog QuickStart stack.
+      
+      (Recommended): If left blank, a new Virtual cloud network (VCN) and subnet will be created.
+    required: false
+    default: false
+
+  show_advanced_options:
+    title: Use advanced options
+    type: boolean
+    description: |
+      Use an existing Compartment, Group, and User for the Datadog QuickStart stack.
+
+      (Recommended): If left blank, a new Compartment, Group, and User will be created.
+    required: false
+    default: false
+
+  # Networking Options
+  subnet_ocids:
+    title: Subnet OCIDs
+    type: text
+    multiline: true
+    description: |
+      Provide a list of OCID(s) for existing subnet(s) to use for the Datadog QuickStart stack. Enter one OCID per line. Do not add commas. 
+      The Datadog QuickStart stack will be deployed in the region corresponding to each subnet. 
+      Each subnet OCID should be in the format: ocid1.subnet.oc[0-9].* 
+      Example: ocid1.subnet.oc1.iad.abcedfgh. 
+      (Recommended): If left blank, a new Virtual cloud network (VCN) and subnet will be created in each region in this tenancy.
+    required: false      
+    default: ""
+    visible: ${choose_subnet}
 
   # Datadog Environment
   datadog_api_key:
     title: Datadog API Key
     type: string
-    description: The API key for sending message to datadog endpoints.
+    description: |
+      The API key for sending messages to Datadog endpoints. See <a href="https://docs.datadoghq.com/account_management/api-app-keys/" target="_blank">Datadog API Key</a> for more information.
     required: true
     sensitive: true
     password: true
     confirmation: true
 
   datadog_app_key:
-    title: Datadog APP Key
+    title: Datadog Application Key
     type: string
-    description: The APP key for establishing integration with Datadog.
+    description: |
+      The Application key for creating and updating an integration with Datadog. See <a href="https://docs.datadoghq.com/account_management/api-app-keys/" target="_blank">Datadog Application Key</a> for more information.
     required: true
     sensitive: true
     password: true
@@ -43,5 +89,39 @@ variables:
   datadog_site:
     title: Datadog Site
     type: string
-    description: The site for Datadog.
+    description: |
+      The site name for your Organization's Datadog endpoint (e.g. datadoghq.com, datadoghq.eu, etc.)
+      This is the "Site Parameter" in the following <a href="https://docs.datadoghq.com/getting_started/site/#access-the-datadog-site" target="_blank">table from the Datadog documentation</a> .
     required: true
+
+  compartment_id:
+    title: Compartment
+    description: |
+      <strong>This is uncommon.</strong>
+      Choose an existing compartment to place all the resources created by Datadog.
+    type: oci:identity:compartment:id
+    required: false
+    default: null
+    visible: ${show_advanced_options}
+
+  existing_user_id:
+    title: User ID
+    type: string
+    description: |
+      <strong>This is uncommon.</strong>
+      Provide the OCID of an existing OCI User for Datadog authentication. If you provide a Group, User ID cannot be left blank. The OCI User must belong to the current Identity Domain and be a member of the specified Group. 
+      (Recommended): If both Group and User are left blank, a new Group and User will be created in the current Identity Domain.
+    required: false
+    default: null
+    visible: ${show_advanced_options}
+
+  existing_group_id:
+    title: Group ID
+    type: string
+    description: |
+      <strong>This is uncommon.</strong>
+      Provide the OCID of an existing OCI Group for Datadog authentication. If you provide a Group, User ID cannot be left blank. The Group must belong to the current Identity Domain. 
+      (Recommended): If both Group and User are left blank, a new Group and User will be created in the current Identity Domain.
+    required: false
+    default: null
+    visible: ${show_advanced_options}

--- a/datadog-integration/variables.tf
+++ b/datadog-integration/variables.tf
@@ -42,3 +42,31 @@ variable "datadog_site" {
   type        = string
   description = "The Datadog site to send data to (e.g., datadoghq.com, datadoghq.eu)"
 }
+
+#*************************************
+#         Advanced Usage Variables
+#*************************************  
+
+variable "subnet_ocids" {
+  type        = string
+  description = "Multiline string of subnet OCIDs (one per line) to use for the Datadog infrastructure. Each subnet OCID should be in the format: ocid1.subnet.oc[0-9].*"
+  default     = ""
+}
+
+variable "compartment_id" {
+  type        = string
+  description = "OCID of the compartment to create or use for Datadog resources. If null, a compartment named 'Datadog' will be created in the tenancy."
+  default     = null
+}
+
+variable "existing_user_id" {
+  type        = string
+  description = "The OCID of the existing user to use for DDOG authentication"
+  default     = null
+}
+
+variable "existing_group_id" {
+  type        = string
+  description = "The OCID of the existing group to use for DDOG authentication"
+  default     = null
+}


### PR DESCRIPTION
## What

ECI-650, ECI-684, ECI-649: changes to allow "advanced" parameters as inputs.
This is meant to be run from OCI RM Stack.
1. Non default domain usage: the domain is the currently logged in domain. Default is no longer assumed.
2. Choice of subnet for forwarding functions: allow input of a list of subnet OCIDs, one per region. The final set of regional stacks is an intersection of (tenancy subscribed regions, domain replicated regions, input subnet regions]. This input is optional. If left empty (default), the stack creates a VCN with subnets in all subscribed regions.
3. Choice of Compartment for deploying stack resources. If left empty, we will create/use the "Datadog" compartment.
4. Choice of Group/User. If left empty (default), we create a User and Group. Otherwise, we use the supplied User & Group. A sizeable amount of the code in this PR revolves around validating these inputs (ensure User belongs to Group, either both are null or neither is, ensure Group belongs to domain).

## Why

Multiple requests.

## How was it tested?

Manually.

