### PR TITLE
Retry Regional Stack Job Creation

### DIFF
--- a/datadog-integration/regional_stack.tf
+++ b/datadog-integration/regional_stack.tf
@@ -77,7 +77,7 @@ resource "null_resource" "regional_stacks_create_apply" {
     JOB_ID=""
     for attempt in {1..5}; do
       echo "Attempting to create job (attempt $attempt/5)..."
-      if JOB_ID=$(oci resource-manager job create-apply-job --stack-id $STACK_ID $WAIT_COMMAND --execution-plan-strategy AUTO_APPROVED --region ${each.key} --query "data.id" 2>/dev/null); then
+      if JOB_ID=$(oci resource-manager job create-apply-job --stack-id $STACK_ID $WAIT_COMMAND --execution-plan-strategy AUTO_APPROVED --region ${each.key} --query "data.id"); then
         echo "Job created successfully: $JOB_ID for region ${each.key}"
         break
       else


### PR DESCRIPTION
## What

- Wait for Stack to become Active before kicking off a job
- Defensively retry job creation 5 times if they fail.
- Job Creation Failure won't fail the stack

## Why
- Resiliency to stack apply

## Testing
- [Stack](https://cloud.oracle.com/resourcemanager/stacks/ocid1.ormstack.oc1.sa-vinhedo-1.amaaaaaai76osliat6i2y5v7p2sf5iu2s7mdkxtign6jjr7h7uh6rg3j3xaq?region=sa-vinhedo-1)