### PR TITLE
ECI-640 Add image sha to OCI functions

### DIFF
--- a/datadog-integration/data.tf
+++ b/datadog-integration/data.tf
@@ -7,8 +7,8 @@ data "external" "supported_regions" {
   program  = ["bash", "${path.module}/docker_image_check.sh"]
 
   query = {
-    region         = each.key
-    regionKey      = each.value.region_key
+    region    = each.key
+    regionKey = each.value.region_key
   }
 }
 

--- a/datadog-integration/locals.tf
+++ b/datadog-integration/locals.tf
@@ -15,26 +15,26 @@ locals {
 
 #Auth Variables
 locals {
-  user_name        = "dd-svc"
-  user_group_name  = "${local.user_name}-admin"
+  user_name              = "dd-svc"
+  user_group_name        = "${local.user_name}-admin"
   user_group_policy_name = "${local.user_name}-policy"
-  dg_sch_name      = "dd-dynamic-group-connectorhubs"
-  dg_fn_name       = "dd-dynamic-group-functions"
-  dg_policy_name   = "dd-dynamic-group-policy"
-  matching_domain_id  = [for k, v in data.oci_identity_domains_user.user_in_domain : k if v.emails != null][0]
+  dg_sch_name            = "dd-dynamic-group-connectorhubs"
+  dg_fn_name             = "dd-dynamic-group-functions"
+  dg_policy_name         = "dd-dynamic-group-policy"
+  matching_domain_id     = [for k, v in data.oci_identity_domains_user.user_in_domain : k if v.emails != null][0]
   matching_domain = [
     for d in data.oci_identity_domains.all_domains.domains : d
     if d.id == local.matching_domain_id
   ][0]
 
   domain_display_name = local.matching_domain.display_name
-  idcs_endpoint      = local.matching_domain.url
-  email            = data.oci_identity_domains_user.user_in_domain[local.matching_domain_id].emails[0].value
+  idcs_endpoint       = local.matching_domain.url
+  email               = data.oci_identity_domains_user.user_in_domain[local.matching_domain_id].emails[0].value
 }
 
 # Variables for regions
 locals {
-  subscribed_regions = [for region in data.oci_identity_region_subscriptions.subscribed_regions.region_subscriptions : region]
+  subscribed_regions      = [for region in data.oci_identity_region_subscriptions.subscribed_regions.region_subscriptions : region]
   subscribed_regions_list = [for region in local.subscribed_regions : region.region_name]
 
   # All supported regions list based on docker image existence
@@ -46,6 +46,6 @@ locals {
     for region in local.subscribed_regions :
     region.region_name => region
   })
-  
+
   subscribed_regions_set = toset(local.subscribed_regions_list)
 }

--- a/datadog-integration/main.tf
+++ b/datadog-integration/main.tf
@@ -1,8 +1,8 @@
 resource "null_resource" "precheck_marker" {
   provisioner "local-exec" {
-    when    = create
+    when       = create
     on_failure = fail
-    command = <<-EOT
+    command    = <<-EOT
       python ${path.module}/pre_check.py \
         --tenancy-id '${var.tenancy_ocid}' \
         --is-home-region '${local.is_current_region_home_region}' \
@@ -22,7 +22,7 @@ resource "null_resource" "precheck_marker" {
 }
 
 module "compartment" {
-  depends_on = [null_resource.precheck_marker]
+  depends_on            = [null_resource.precheck_marker]
   source                = "./modules/compartment"
   compartment_name      = local.compartment_name
   parent_compartment_id = var.tenancy_ocid
@@ -30,7 +30,7 @@ module "compartment" {
 }
 
 module "kms" {
-  depends_on = [null_resource.precheck_marker]
+  depends_on      = [null_resource.precheck_marker]
   source          = "./modules/kms"
   count           = local.is_current_region_home_region ? 1 : 0
   compartment_id  = module.compartment.id
@@ -39,21 +39,21 @@ module "kms" {
 }
 
 module "auth" {
-  depends_on = [null_resource.precheck_marker]
-  source           = "./modules/auth"
-  count            = local.is_current_region_home_region ? 1 : 0
-  user_name        = local.user_name
-  tenancy_id       = var.tenancy_ocid
-  tags             = local.tags
-  current_user_id  = var.current_user_ocid
-  compartment_name = local.compartment_name
-  compartment_id   = module.compartment.id
-  user_group_name           = local.user_group_name
-  user_group_policy_name    = local.user_group_policy_name
-  dg_sch_name              = local.dg_sch_name
-  dg_fn_name               = local.dg_fn_name
-  dg_policy_name           = local.dg_policy_name
-  email                    = local.email
+  depends_on             = [null_resource.precheck_marker]
+  source                 = "./modules/auth"
+  count                  = local.is_current_region_home_region ? 1 : 0
+  user_name              = local.user_name
+  tenancy_id             = var.tenancy_ocid
+  tags                   = local.tags
+  current_user_id        = var.current_user_ocid
+  compartment_name       = local.compartment_name
+  compartment_id         = module.compartment.id
+  user_group_name        = local.user_group_name
+  user_group_policy_name = local.user_group_policy_name
+  dg_sch_name            = local.dg_sch_name
+  dg_fn_name             = local.dg_fn_name
+  dg_policy_name         = local.dg_policy_name
+  email                  = local.email
 }
 
 module "key" {

--- a/datadog-integration/modules/key/data.tf
+++ b/datadog-integration/modules/key/data.tf
@@ -11,6 +11,6 @@ data "oci_identity_domain" "selected_domain" {
 }
 
 data "local_sensitive_file" "private_key" {
-  filename = "/tmp/sshkey"
+  filename   = "/tmp/sshkey"
   depends_on = [terraform_data.manage_api_key]
 }

--- a/datadog-integration/modules/key/locals.tf
+++ b/datadog-integration/modules/key/locals.tf
@@ -1,6 +1,6 @@
 locals {
   user_id = var.existing_user_id
   # Always get the IDCS endpoint from the selected domain
-  idcs_endpoint = data.oci_identity_domain.selected_domain.url
+  idcs_endpoint  = data.oci_identity_domain.selected_domain.url
   endpoint_param = "--endpoint ${local.idcs_endpoint}"
 }

--- a/datadog-integration/modules/key/main.tf
+++ b/datadog-integration/modules/key/main.tf
@@ -16,7 +16,7 @@ resource "terraform_data" "manage_api_key" {
     always_run = timestamp()
   }
   provisioner "local-exec" {
-    command = <<-EOT
+    command     = <<-EOT
       set -e
 
       # Clean up any existing key files

--- a/datadog-integration/modules/key/outputs.tf
+++ b/datadog-integration/modules/key/outputs.tf
@@ -1,5 +1,5 @@
 output "private_key" {
-  value     = data.local_sensitive_file.private_key.content
-  sensitive = true
+  value       = data.local_sensitive_file.private_key.content
+  sensitive   = true
   description = "The private key"
 } 

--- a/datadog-integration/modules/regional-stacks/data.tf
+++ b/datadog-integration/modules/regional-stacks/data.tf
@@ -1,0 +1,31 @@
+data "http" "token_logs" {
+  url = local.token_logs
+}
+
+data "http" "token_metrics" {
+  url = local.token_metrics
+}
+
+locals {
+  logs_token        = jsondecode(data.http.token_logs.response_body).token
+  metrics_token     = jsondecode(data.http.token_metrics.response_body).token
+  image_sha_logs    = data.http.logs_image.response_headers.Docker-Content-Digest
+  image_sha_metrics = data.http.metrics_image.response_headers.Docker-Content-Digest
+}
+
+
+data "http" "logs_image" {
+  url = local.image_url_logs
+  request_headers = {
+    Accept        = "application/vnd.oci.image.index.v1+json"
+    Authorization = "Bearer ${local.logs_token}"
+  }
+}
+
+data "http" "metrics_image" {
+  url = local.image_url_metrics
+  request_headers = {
+    Accept        = "application/vnd.oci.image.index.v1+json"
+    Authorization = "Bearer ${local.metrics_token}"
+  }
+}

--- a/datadog-integration/modules/regional-stacks/locals.tf
+++ b/datadog-integration/modules/regional-stacks/locals.tf
@@ -2,6 +2,12 @@ locals {
   registry_host      = lower("${var.region_key}.ocir.io/iddfxd5j9l2o")
   metrics_image_path = "${local.registry_host}/oci-datadog-forwarder/metrics:latest"
   logs_image_path    = "${local.registry_host}/oci-datadog-forwarder/logs:latest"
+  token_base_path    = "https://${var.region_key}.ocir.io/20180419/docker/token?service=${var.region_key}.ocir.io&scope=repository:iddfxd5j9l2o/oci-datadog-forwarder"
+  token_logs         = "${local.token_base_path}/logs:pull"
+  token_metrics      = "${local.token_base_path}/metrics:pull"
+  image_base_path    = "https://${var.region_key}.ocir.io/v2/iddfxd5j9l2o/oci-datadog-forwarder"
+  image_url_logs     = "${local.image_base_path}/logs/manifests/latest"
+  image_url_metrics  = "${local.image_base_path}/metrics/manifests/latest"
 
   config = {
     "DD_SITE"                  = var.datadog_site,

--- a/datadog-integration/modules/regional-stacks/main.tf
+++ b/datadog-integration/modules/regional-stacks/main.tf
@@ -5,6 +5,10 @@ terraform {
       source  = "oracle/oci"
       version = "5.46.0"
     }
+    http = {
+      source  = "hashicorp/http"
+      version = "3.5.0"
+    }
   }
 }
 
@@ -25,6 +29,8 @@ resource "oci_functions_function" "logs_function" {
   memory_in_mbs  = "1024"
   freeform_tags  = var.tags
   image          = local.logs_image_path
+  image_digest   = local.image_sha_logs
+
 }
 
 resource "oci_functions_function" "metrics_function" {
@@ -33,6 +39,7 @@ resource "oci_functions_function" "metrics_function" {
   memory_in_mbs  = "512"
   freeform_tags  = var.tags
   image          = local.metrics_image_path
+  image_digest   = local.image_sha_metrics
 }
 
 module "vcn" {

--- a/datadog-integration/regional_stack.tf
+++ b/datadog-integration/regional_stack.tf
@@ -22,7 +22,7 @@ resource "terraform_data" "stack_digest" {
 resource "null_resource" "regional_stacks_create_apply" {
   depends_on = [terraform_data.regional_stack_zip, terraform_data.stack_digest]
   # Not using local.supported_region_set here because that is determined during apply time and terraform needs to be aware of exact length during plan stage
-  for_each   = local.subscribed_regions_set
+  for_each = local.subscribed_regions_set
   provisioner "local-exec" {
     working_dir = path.module
     command     = <<EOT
@@ -85,7 +85,7 @@ resource "terraform_data" "regional_stacks_destroy" {
   depends_on = [terraform_data.regional_stack_zip, terraform_data.stack_digest]
   for_each   = local.subscribed_regions_set
   input = {
-    compartment = module.compartment.id
+    compartment     = module.compartment.id
     stack_digest_id = terraform_data.stack_digest.id
   }
 


### PR DESCRIPTION

**what:**
* Find the image sha of the metrics and logs image with `latest` tag and use it as image digest paramter in the function.
* This ensures that re-running the stack will apply the latest digest to the function in case the image is updated.
* Some terraform formatting of existing files. No actual changes. All necessary changes in: `datadog-integration/modules/regional-stacks/`

