### PR TITLE
bug fix: ensure final region set only includes regions where docker image is available

### DIFF
--- a/datadog-integration/locals.tf
+++ b/datadog-integration/locals.tf
@@ -134,10 +134,19 @@ locals {
     ]) > 1
   ]
 
-  # Intersection of subscribed regions, regions in domain, and subnet regions (compatible with Terraform <= 1.5.x)
+  docker_image_enabled_regions = toset([
+    for region in keys(local.subscribed_regions_list) : region
+    if local.supported_regions[region].result.failure == ""
+  ])
+
+  # Intersection of subscribed regions, regions in domain, subnet regions (compatible with Terraform <= 1.5.x)
+  # and regions where the docker image is available
   # Only create regional stacks for regions that meet all three criteria
   target_regions_for_stacks = length(local.subnet_ocids_list) > 0 ? toset([
     for region in local.subscribed_regions_list : region
-    if contains(tolist(local.regions_in_domain_set), region) && contains(tolist(local.subnet_regions), region)
-  ]) : local.subscribed_regions_set
+    if contains(tolist(local.regions_in_domain_set), region) && contains(tolist(local.subnet_regions), region) && local.supported_regions[region].result.failure == ""
+  ]) : toset([
+    for region in local.subscribed_regions_list : region
+    if local.supported_regions[region].result.failure == ""
+  ])
 }

--- a/datadog-integration/main.tf
+++ b/datadog-integration/main.tf
@@ -121,6 +121,7 @@ resource "null_resource" "region_intersection_info" {
       echo "Subscribed regions in tenancy: ${join(", ", sort(tolist(local.subscribed_regions_set)))}"
       echo "Regions available in identity domain: ${join(", ", sort(tolist(local.regions_in_domain_set)))}"
       echo "Regions with provided subnet OCIDs: ${length(local.subnet_ocids_list) > 0 ? join(", ", sort(tolist(local.subnet_regions))) : "None (will create subnets in all subscribed regions)"}"
+      echo "Regions where Docker image is available: ${join(", ", sort(tolist(local.docker_image_enabled_regions)))}"
       echo "Target regions for regional stack deployment: ${join(", ", sort(tolist(local.target_regions_for_stacks)))}"
       echo "Number of regional stacks to be created: ${length(local.target_regions_for_stacks)}"
       echo "================================================================================="


### PR DESCRIPTION
The final region set was the intersection of user input, domain supported and tenancy supported regions.
We forgot the check for availability of docker images in all the recent changes.


