### PR TITLE
Add more logging to key module

### DIFF
--- a/datadog-integration/delete_stack.sh
+++ b/datadog-integration/delete_stack.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# Suppress OCI CLI warnings
+export OCI_CLI_SUPPRESS_FILE_PERMISSIONS_WARNING=True
+
 COMPARTMENT=$1
 REGION=$2
 DISPLAY_NAME=$3

--- a/datadog-integration/modules/key/main.tf
+++ b/datadog-integration/modules/key/main.tf
@@ -68,9 +68,6 @@ resource "terraform_data" "manage_api_key" {
       KEY_CONTENT=$(cat /tmp/sshkey.pem)
       echo "Public key content read successfully"
       
-      echo "Calculating fingerprint..."
-      FINGERPRINT=$(openssl rsa -pubout -outform DER -in /tmp/sshkey | openssl md5 -c | awk '{print $2}')
-      echo "Fingerprint calculated: $FINGERPRINT"
       echo '["urn:ietf:params:scim:schemas:oracle:idcs:apikey"]' > /tmp/schemas.json
       echo "{\"value\": \"$USER_INFO\"}" > /tmp/user.json
 
@@ -78,7 +75,7 @@ resource "terraform_data" "manage_api_key" {
       create_key() {
         oci identity-domains api-key create \
           --key "$KEY_CONTENT" \
-          --fingerprint "$FINGERPRINT" \
+          --fingerprint "" \
           --schemas file:///tmp/schemas.json \
           --user file:///tmp/user.json \
           ${local.endpoint_param} \

--- a/datadog-integration/modules/key/main.tf
+++ b/datadog-integration/modules/key/main.tf
@@ -20,25 +20,57 @@ resource "terraform_data" "manage_api_key" {
     command     = <<-EOT
       set -e
 
+      # Suppress OCI CLI warnings
+      export OCI_CLI_SUPPRESS_FILE_PERMISSIONS_WARNING=True
+
       # Clean up any existing key files
       rm -f /tmp/sshkey*
 
       # Generate private key in PKCS8 format
       ssh-keygen -b 2048 -t rsa -m PKCS8 -f /tmp/sshkey -q -N "" -C "oci-api-key"
       openssl rsa -in /tmp/sshkey -pubout -out /tmp/sshkey.pem
+      echo "SSH key pair generated successfully"
 
       # Get user's IDCS ID
-      USER_INFO=$(oci identity-domains users list ${local.endpoint_param} ${var.auth_method} --all --raw-output | \
-        jq -r '.data.resources[] | select(.ocid == "'"${local.user_id}"'") | .id')
+      echo "Starting user lookup for OCID: ${local.user_id}"
       
-      if [ -z "$USER_INFO" ] || [ "$USER_INFO" = "null" ]; then
-        echo "Failed to find user with OCID: ${local.user_id}"
+      # Execute OCI CLI command with debugging
+      if ! OCI_OUTPUT=$(oci identity-domains users list ${local.endpoint_param} ${var.auth_method} --read-timeout 60 --all --raw-output 2>&1); then
+        echo "ERROR: OCI CLI command failed"
+        echo "Command output: $OCI_OUTPUT"
         exit 1
       fi
+      
+      echo "OCI CLI command completed successfully"
+      echo "Parsing JSON response with jq..."
+      
+      # Parse JSON with jq
+      if ! USER_INFO=$(echo "$OCI_OUTPUT" | jq -r '.data.resources[] | select(.ocid == "'"${local.user_id}"'") | .id' 2>&1); then
+        echo "ERROR: jq parsing failed"
+        echo "Raw OCI output (first 1000 chars):"
+        echo "$OCI_OUTPUT" | head -c 1000
+        exit 1
+      fi
+      
+      echo "JSON parsing completed. User ID: $USER_INFO"
+      
+      if [ -z "$USER_INFO" ] || [ "$USER_INFO" = "null" ]; then
+        echo "ERROR: Failed to find user with OCID: ${local.user_id}"
+        echo "Raw OCI output (first 1000 chars):"
+        echo "$OCI_OUTPUT" | head -c 1000
+        exit 1
+      fi
+      
+      echo "User lookup successful. Proceeding to key creation..."
 
       # Prepare key creation
+      echo "Reading public key content..."
       KEY_CONTENT=$(cat /tmp/sshkey.pem)
+      echo "Public key content read successfully"
+      
+      echo "Calculating fingerprint..."
       FINGERPRINT=$(openssl rsa -pubout -outform DER -in /tmp/sshkey | openssl md5 -c | awk '{print $2}')
+      echo "Fingerprint calculated: $FINGERPRINT"
       echo '["urn:ietf:params:scim:schemas:oracle:idcs:apikey"]' > /tmp/schemas.json
       echo "{\"value\": \"$USER_INFO\"}" > /tmp/user.json
 

--- a/datadog-integration/regional_stack.tf
+++ b/datadog-integration/regional_stack.tf
@@ -31,6 +31,8 @@ resource "null_resource" "regional_stacks_create_apply" {
   provisioner "local-exec" {
     working_dir = path.module
     command     = <<EOT
+    # Suppress OCI CLI warnings
+    export OCI_CLI_SUPPRESS_FILE_PERMISSIONS_WARNING=True
 
     echo "Checking if the region ${each.key} is supported or not"
     VALUE="${local.supported_regions[each.key].result.failure}"


### PR DESCRIPTION
## What

- If we run OCI CLI commands, suppress warnings to ensure json doesn't get corrupted
- Add detailed logging in key module

## Why
- Debugging API Key generation related issues

## Testing
- Deployed the [stack](https://cloud.oracle.com/resourcemanager/stacks/ocid1.ormstack.oc1.sa-vinhedo-1.amaaaaaai76osliaw4ebbudgncq7kamhhcd3moic3gsajd6rlkmbci4e3kna?region=sa-vinhedo-1).