### PR TITLE
optimize user id lookup

### DIFF
--- a/datadog-integration/modules/key/main.tf
+++ b/datadog-integration/modules/key/main.tf
@@ -35,7 +35,7 @@ resource "terraform_data" "manage_api_key" {
       echo "Starting user lookup for OCID: ${local.user_id}"
       
       # Execute OCI CLI command with debugging
-      if ! OCI_OUTPUT=$(oci identity-domains users list ${local.endpoint_param} ${var.auth_method} --read-timeout 60 --all --raw-output 2>&1); then
+      if ! OCI_OUTPUT=$(oci identity-domains users list ${local.endpoint_param} ${var.auth_method} --read-timeout 60 --filter "ocid eq \"${local.user_id}\"" --raw-output 2>&1); then
         echo "ERROR: OCI CLI command failed"
         echo "Command output: $OCI_OUTPUT"
         exit 1


### PR DESCRIPTION
## What
- Query one user instead of looking over all users of a domain

## Why
- Performance improvement

## Testing
- [Stack](https://cloud.oracle.com/resourcemanager/stacks/ocid1.ormstack.oc1.sa-vinhedo-1.amaaaaaai76osliaz5awyngwleapg32p7rh2ad4hwhtbwbyrn43jgxruhoqq?region=sa-vinhedo-1)