### PR TITLE
Eci 904 updating stack to include logs config

### DIFF
--- a/datadog-integration/main.tf
+++ b/datadog-integration/main.tf
@@ -260,6 +260,7 @@ module "integration" {
   user_ocid                       = module.auth[0].user_id
   subscribed_regions              = tolist(local.final_regions_for_stacks)
   datadog_resource_compartment_id = module.compartment.id
+  logs_config                     = var.logs_config
 }
 
 

--- a/datadog-integration/modules/integration/locals.tf
+++ b/datadog-integration/modules/integration/locals.tf
@@ -17,6 +17,9 @@ locals {
         }
         dd_compartment_id : var.datadog_resource_compartment_id
         dd_stack_id : try(data.external.stack_info.result.stack_id, "")
+        logs_config : {
+          Enabled: var.logs_config
+        }
       }
     }
   }

--- a/datadog-integration/modules/integration/variables.tf
+++ b/datadog-integration/modules/integration/variables.tf
@@ -48,3 +48,9 @@ variable "datadog_resource_compartment_id" {
   type        = string
   description = "The compartment id in which datadog resources are present."
 }
+
+variable "logs_config" {
+  type        = bool
+  description = "Indicates if logs should be enabled/disabled"
+  default     = false
+}

--- a/datadog-integration/providers.tf
+++ b/datadog-integration/providers.tf
@@ -28,5 +28,6 @@ provider "restapi" {
     "DD-API-KEY"         = var.datadog_api_key
     "DD-APPLICATION-KEY" = var.datadog_app_key
     "Content-Type"       = "application/json"
+    "logs-config"        = "no-ui-override"
   }
 }

--- a/datadog-integration/schema.yaml
+++ b/datadog-integration/schema.yaml
@@ -18,6 +18,7 @@ variableGroups:
       - ${datadog_app_key}
       - ${datadog_api_key}
       - ${datadog_site}
+      - ${logs_config}
   - title: "(Optional) Choose specific subnet(s)"
     variables:
       - ${choose_subnet}
@@ -91,6 +92,14 @@ variables:
       The site name for your Organization's Datadog endpoint (e.g. datadoghq.com, datadoghq.eu, etc.)
       This is the "Site Parameter" in the following <a href="https://docs.datadoghq.com/getting_started/site/#access-the-datadog-site" target="_blank">table from the Datadog documentation</a> .
     required: true
+
+  logs_config:
+    title: Logs Config
+    type: string
+    description: |
+      Indicates if logs should be enabled/disabled
+    required: true
+    default: false
 
   compartment_id:
     title: Compartment

--- a/datadog-integration/schema.yaml
+++ b/datadog-integration/schema.yaml
@@ -94,7 +94,7 @@ variables:
     required: true
 
   logs_config:
-    title: Logs Config
+    title: Logs Enabled
     type: string
     description: |
       Indicates if logs should be enabled/disabled

--- a/datadog-integration/variables.tf
+++ b/datadog-integration/variables.tf
@@ -70,3 +70,9 @@ variable "existing_group_id" {
   description = "The OCID of the existing group to use for DDOG authentication"
   default     = null
 }
+
+variable "logs_config" {
+  type        = bool
+  description = "Indicates if logs should be enabled/disabled"
+  default     = false
+}


### PR DESCRIPTION
What: Adding logs_config variable to terraform code for the oci stack
Why: Allows us to enable logs from OCI quickstart 
How: Add it to schema and variables files then test by constructing a stack in Oracle's UI